### PR TITLE
Add Radio module

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export * from "./modules/Typography";
 export * from "./modules/Button";
 export * from "./modules/Chip";
 export * from "./modules/Icon";
+export * from "./modules/Radio";
 export * from "./modules/TextInput";
 export * from "./modules/Checkbox";
 export * from "./base";

--- a/src/modules/Radio/Radio.story.mdx
+++ b/src/modules/Radio/Radio.story.mdx
@@ -1,0 +1,344 @@
+import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { H3 } from "../Typography/Typography";
+import { CustomRadio } from "./Radio.story";
+import Radio from "./Radio";
+
+<Meta title="Components| Radio" />
+
+# Radio
+
+`Radio buttons` allow the user to choose an option out of a set of related options.
+Thus, they should be used in `Radio groups` and only one button should be selected at the same time.
+
+Please do not mix up `Radio buttons` with `Checkboxes`. From MDN's web docs on Radio buttons:
+
+```
+Note: Checkboxes are similar to radio buttons, but with an important distinction: radio buttons are designed for selecting one value out of a set, whereas checkboxes let you turn individual values on and off.
+Where multiple controls exist, radio buttons allow one to be selected out of them all, whereas checkboxes allow multiple values to be selected.
+```
+
+### Radio button
+
+<Preview>
+  <Story name="Radio">
+    <Radio value="radio1" label="Example radio" />
+  </Story>
+</Preview>
+
+### Radio button with given selected value
+
+<Preview>
+  <Story name="Radio with selected value">
+    <Radio
+      value="radio2"
+      label="Example selected radio"
+      selectedValue="radio2"
+    />
+  </Story>
+</Preview>
+
+### Disabled Radio button
+
+<Preview>
+  <Story name="Disabled radio">
+    <Radio value="radio3" label="Example disabled radio" disabled />
+  </Story>
+</Preview>
+
+### Radio button with error
+
+<Preview>
+  <Story name="Radio with error">
+    <Radio value="radio4" label="Example error radio" hasError />
+  </Story>
+</Preview>
+
+### Radio button with custom input styles
+
+The default `input` element has specific styles depending on the operating system.
+They can be removed with `apperance: none` and some custom syles can be applied, but they are pretty limited.
+Therefore, it is possible to pass a custom DOM structure as the `Radio`'s `children` prop so there are no limits regarding styling.
+
+Here is an example of a custom radio button using material ui's styles.
+
+```javascript
+const styleSheet: ThemeStyleSheetFactory = () => ({
+  svg: {
+    fill: "none",
+    verticalAlign: "middle"
+  },
+  circle: {
+    strokeWidth: 2,
+    stroke: "#C8CCD4"
+  },
+  innerPath: {
+    stroke: "#008FFF",
+    strokeWidth: 6,
+    strokeDasharray: 19,
+    strokeDashoffset: 19,
+    "@selectors": {
+      "&.checked": {
+        strokeDashoffset: 38
+      }
+    }
+  },
+  outerPath: {
+    stroke: "#008FFF",
+    strokeWidth: 2,
+    strokeDasharray: 57,
+    strokeDashoffset: 57,
+    "@selectors": {
+      "&.checked": {
+        strokeDashoffset: 0
+      }
+    }
+  }
+});
+
+const CustomRadio: React.FC<IProps> = ({ selectedValue, ...props }) => {
+  const StyledRadio = Radio.extendStyles(theme => ({
+    input: {
+      marginRight: theme.spaceUnit.xxs
+    }
+  }));
+
+  const [styles, cx] = useStyles(styleSheet);
+
+  return (
+    <StyledRadio selectedValue={selectedValue} {...props}>
+      <svg
+        width="20px"
+        height="20px"
+        viewBox="0 0 20 20"
+        className={cx(styles.svg)}
+      >
+        <circle cx="10" cy="10" r="9" className={cx(styles.circle)}></circle>
+        <path
+          d="..."
+          className={cx("inner", styles.innerPath, selectedValue && "checked")}
+        ></path>
+        <path
+          d="..."
+          className={cx("outer", styles.outerPath, selectedValue && "checked")}
+        ></path>
+      </svg>
+    </StyledRadio>
+  );
+};
+```
+
+<Preview>
+  <Story name="Custom selected radio">
+    <CustomRadio
+      value="radio5"
+      label="Example selected custom radio"
+      selectedValue={"radio5"}
+    />
+  </Story>
+  <Story name="Custom radio">
+    <CustomRadio value="radio6" label="Example custom radio" />
+  </Story>
+</Preview>
+
+### Available props
+
+<table width="100%">
+  <thead>
+    <tr>
+      <th>Prop Name</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>children</td>
+      <td>ReactElement</td>
+      <td>
+        Optionally pass a React element to provide a custom input for styling
+        purposes
+      </td>
+    </tr>
+    <tr>
+      <td>disabled</td>
+      <td>boolean</td>
+      <td>Flag indicating whether user can interact with radio button</td>
+    </tr>
+    <tr>
+      <td>hasError</td>
+      <td>boolean</td>
+      <td>Flag indicating whether there is an error present in radio button</td>
+    </tr>
+    <tr>
+      <td>label</td>
+      <td>string</td>
+      <td>The radio button's label</td>
+    </tr>
+    <tr>
+      <td>name</td>
+      <td>string</td>
+      <td>
+        This prop is used to group a set of radio buttons that share the same
+        name prop. <br /> This prop should not be passed manually, as it is
+        injected by the radio button's <i>RadioGroup</i>.
+      </td>
+    </tr>
+    <tr>
+      <td>selectedValue</td>
+      <td>string</td>
+      <td>
+        The radio button compares <i>selectedValue</i> to its own value to
+        determine whether it is selected. <br /> This prop should not be passed
+        manually, as it is injected by the radio button's <i>RadioGroup</i>.
+      </td>
+    </tr>
+    <tr>
+      <td>value</td>
+      <td>string</td>
+      <td>
+        This <i>value</i> is used to determine whether the radio button
+        selected.
+      </td>
+    </tr>
+    <tr>
+      <td>onValueSelect</td>
+      <td>function</td>
+      <td>
+        Callback that is invoked whenever the radio button is clicked on (given
+        <i> isDisabled</i> is <i>false</i>)
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### Extendable styles
+
+<table width="100%">
+  <thead>
+    <tr>
+      <th>Style name</th>
+      <th>@selectors</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>input</td>
+      <td></td>
+      <td>
+        This style affects the radio button's <i>input</i> element
+      </td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>:hover</td>
+      <td>
+        This style affects the radio button's <i>input</i> element when the user
+        hovers over the button
+      </td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>:active</td>
+      <td>
+        This style affects the radio button's <i>input</i> element when the
+        button is active (being clicked on)
+      </td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>.checked</td>
+      <td>
+        This style affects the radio button's <i>input</i> element when the
+        button is selected
+      </td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>.disabled</td>
+      <td>
+        This style affects the radio button's <i>input</i> element when the
+        button is disabled
+      </td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>.error</td>
+      <td>
+        This style affects the radio button's <i>input</i> element when the
+        button has an error
+      </td>
+    </tr>
+    <tr>
+      <td>label</td>
+      <td></td>
+      <td>
+        This style affects the radio button's <i>label</i> element
+      </td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>:hover</td>
+      <td>
+        This style affects the radio button's <i>label</i> element when the user
+        hovers over the button
+      </td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>:active</td>
+      <td>
+        This style affects the radio button's <i>label</i> element when the
+        button is active (being clicked on)
+      </td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>.checked</td>
+      <td>
+        This style affects the radio button's <i>label</i> element when the
+        button is selected
+      </td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>.disabled</td>
+      <td>
+        This style affects the radio button's <i>label</i> element when the
+        button is disabled
+      </td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>.error</td>
+      <td>
+        This style affects the radio button's <i>label</i> element when the
+        button has an error
+      </td>
+    </tr>
+    <tr>
+      <td>wrapper</td>
+      <td></td>
+      <td>
+        This style affects the element that wraps the <i>input</i> and{" "}
+        <i>label</i> elements
+      </td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>.disabled</td>
+      <td>
+        This style affects the element that wraps the <i>input</i> and{" "}
+        <i>label</i> elements when the button is disabled
+      </td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>.error</td>
+      <td>
+        This style affects the element that wraps the <i>input</i> and{" "}
+        <i>label</i> elements when the button has error
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/src/modules/Radio/Radio.story.tsx
+++ b/src/modules/Radio/Radio.story.tsx
@@ -1,0 +1,85 @@
+import React, { ReactElement } from "react";
+import { useStyles } from "../../base";
+import { ThemeStyleSheetFactory } from "../../types";
+import Radio from "./Radio";
+
+interface IProps {
+  children: ReactElement;
+  hasError?: boolean;
+  label: string;
+  selectedValue?: string;
+  value: string;
+  onValueSelect?: (value: string) => void;
+}
+
+const styleSheet: ThemeStyleSheetFactory = () => ({
+  svg: {
+    fill: "none",
+    verticalAlign: "middle"
+  },
+  circle: {
+    strokeWidth: 2,
+    stroke: "#C8CCD4"
+  },
+  innerPath: {
+    stroke: "#008FFF",
+    strokeWidth: 6,
+    strokeDasharray: 19,
+    strokeDashoffset: 19,
+    "@selectors": {
+      "&.checked": {
+        strokeDashoffset: 38
+      }
+    }
+  },
+  outerPath: {
+    stroke: "#008FFF",
+    strokeWidth: 2,
+    strokeDasharray: 57,
+    strokeDashoffset: 57,
+    "@selectors": {
+      "&.checked": {
+        strokeDashoffset: 0
+      }
+    }
+  }
+});
+
+const CustomRadio: React.FC<IProps> = ({ selectedValue, ...props }) => {
+  const StyledRadio = Radio.extendStyles(theme => ({
+    input: {
+      marginRight: theme.spaceUnit.xxs
+    }
+  }));
+
+  const [styles, cx] = useStyles(styleSheet);
+
+  return (
+    <StyledRadio
+      selectedValue={selectedValue}
+      onValueSelect={() => {
+        console.log("BIG YEET");
+      }}
+      {...props}
+    >
+      <svg
+        width="20px"
+        height="20px"
+        viewBox="0 0 20 20"
+        className={cx(styles.svg)}
+      >
+        <circle cx="10" cy="10" r="9" className={cx(styles.circle)}></circle>
+        <path
+          d="M10,7 C8.34314575,7 7,8.34314575 7,10 C7,11.6568542 8.34314575,13 10,13 C11.6568542,13 13,11.6568542 13,10 C13,8.34314575 11.6568542,7 10,7 Z"
+          className={cx("inner", styles.innerPath, selectedValue && "checked")}
+        ></path>
+        <path
+          d="M10,1 L10,1 L10,1 C14.9705627,1 19,5.02943725 19,10 L19,10 L19,10 C19,14.9705627 14.9705627,19 10,19 L10,19 L10,19 C5.02943725,19 1,14.9705627 1,10 L1,10 L1,10 C1,5.02943725 5.02943725,1 10,1 L10,1 Z"
+          className={cx("outer", styles.outerPath, selectedValue && "checked")}
+        ></path>
+      </svg>
+    </StyledRadio>
+  );
+};
+
+export { CustomRadio };

--- a/src/modules/Radio/Radio.tsx
+++ b/src/modules/Radio/Radio.tsx
@@ -1,0 +1,120 @@
+import React, { useCallback, useMemo, ReactElement } from "react";
+import uuid from "uuid/v4";
+import {
+  StandardProps,
+  WithStylesProps,
+  ThemeStyleSheetFactory
+} from "../../types";
+import { withStyles } from "../../base";
+
+interface IProps extends StandardProps<"input"> {
+  children?: ReactElement;
+  hasError?: boolean;
+  label: string;
+  selectedValue?: string;
+  value: string;
+  onValueSelect?: (value: string) => void;
+}
+
+const styleSheet: ThemeStyleSheetFactory = theme => ({
+  input: {
+    color: theme.colors.primary,
+    cursor: "pointer",
+    ":hover": {},
+    ":active": {},
+    "@selectors": {
+      "&.checked": {},
+      "&.disabled": {
+        cursor: "default"
+      },
+      "&.error": {}
+    }
+  },
+  label: {
+    cursor: "pointer",
+    ":hover": {},
+    ":active": {},
+    "@selectors": {
+      "&.checked": {},
+      "&.disabled": {
+        cursor: "default"
+      },
+      "&.error": {
+        color: theme.colors.alert.alert50
+      }
+    }
+  },
+  wrapper: {
+    display: "flex",
+    alignItems: "center",
+    "@selectors": {
+      "&.checked": {},
+      "&.disabled": {},
+      "&.error": {
+        color: theme.colors.alert.alert50
+      }
+    }
+  }
+});
+
+const Radio: React.FC<IProps & WithStylesProps> = ({
+  children,
+  cx,
+  hasError,
+  label,
+  selectedValue,
+  styles,
+  wrappedRef,
+  onValueSelect,
+  ...props
+}) => {
+  const id = useMemo(() => uuid(), []);
+  const { value, disabled } = props;
+  const isChecked = selectedValue === value;
+
+  const handleChange = useCallback(() => {
+    if (!disabled && onValueSelect) {
+      onValueSelect(value);
+    }
+  }, [disabled, value, onValueSelect]);
+
+  const inputStyles = cx(
+    styles.input,
+    isChecked && "checked",
+    disabled && "disabled",
+    hasError && "error",
+    children && children.props.className
+  );
+
+  return (
+    <div className={cx(styles.wrapper)}>
+      <input
+        checked={isChecked}
+        className={children ? cx({ display: "none" }) : inputStyles}
+        id={id}
+        ref={wrappedRef}
+        type="radio"
+        onChange={handleChange}
+        {...props}
+      />
+      {children &&
+        React.cloneElement(children, {
+          className: inputStyles,
+          onClick: handleChange
+        })}
+      <label
+        htmlFor={id}
+        className={cx(
+          styles.label,
+          isChecked && "checked",
+          disabled && "disabled",
+          hasError && "error"
+        )}
+      >
+        {label}
+      </label>
+    </div>
+  );
+};
+
+export default withStyles(styleSheet)(Radio);

--- a/src/modules/Radio/RadioGroup.story.mdx
+++ b/src/modules/Radio/RadioGroup.story.mdx
@@ -1,0 +1,167 @@
+import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { H3 } from "../Typography/Typography";
+import Radio from "./Radio";
+import RadioGroup from "./RadioGroup";
+import { RadioGroupExample } from "./RadioGroup.story";
+
+<Meta title="Components| RadioGroup" />
+
+# RadioGroup
+
+A `RadioGroup` consists of a set of `Radio buttons`.
+It is responsible for passing the necessary props to every child `Radio button` and for handling changes to the selected option.
+
+The following example is used for the different variations of a `RadioGroup` described below:
+
+```javascript
+class RadioGroupExample extends React.PureComponent<
+  IProps,
+  { selectedValue: string }
+> {
+  constructor(props: any) {
+    super(props);
+
+    this.state = {
+      selectedValue: props.selectedValue
+    };
+  }
+
+  handleChange(selectedValue: string) {
+    this.setState({ selectedValue });
+  }
+
+  render() {
+    const { isDisabled, name } = this.props;
+    const { selectedValue } = this.state;
+
+    return (
+      <RadioGroup
+        isDisabled={isDisabled}
+        name={name}
+        selectedValue={selectedValue}
+        onValueSelect={this.handleChange.bind(this)}
+      >
+        <Radio value={`${name}1`} label="Example Radio 1" />
+        <Radio value={`${name}2`} label="Example Radio 2" />
+        <Radio value={`${name}3`} label="Example Radio 3" />
+      </RadioGroup>
+    );
+  }
+}
+```
+
+### Radio group
+
+<Preview>
+  <Story name="Radio group">
+    <RadioGroupExample name="radioExample" />
+  </Story>
+</Preview>
+
+### Radio group with given selected value
+
+<Preview>
+  <Story name="Radio group with given selected value">
+    <RadioGroupExample
+      name="selectedRadioExample"
+      selectedValue="selectedRadioExample1"
+    />
+  </Story>
+</Preview>
+
+### Disabled Radio group
+
+<Preview>
+  <Story name="Disabled radio group">
+    <RadioGroupExample name="disabledRadioExample" disabled />
+  </Story>
+</Preview>
+
+### Radio group with an error
+
+<Preview>
+  <Story name="Radio group with error">
+    <RadioGroupExample name="errorRadioExample" hasError />
+  </Story>
+</Preview>
+
+### Available props
+
+<table width="100%">
+  <thead>
+    <tr>
+      <th>Prop Name</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>disabled</td>
+      <td>boolean</td>
+      <td>
+        Flag indicating whether user can interact with any radio button that is
+        part of the <i>RadioGroup</i>
+      </td>
+    </tr>
+    <tr>
+      <td>hasError</td>
+      <td>boolean</td>
+      <td>
+        Flag indicating whether there is an error present in <i>RadioGroup</i>.
+        <br />
+        This prop will be injected into each radio button.
+      </td>
+    </tr>
+    <tr>
+      <td>name</td>
+      <td>string</td>
+      <td>
+        This prop is used to group the set of radio buttons that are part of the{" "}
+        <i>RadioGroup</i>. <br />
+        This prop will be injected into each radio button.
+      </td>
+    </tr>
+    <tr>
+      <td>selectedValue</td>
+      <td>string</td>
+      <td>
+        This prop contains the value of the selected radio button (it may also
+        be undefined if no option is selected). <br />
+        This prop will be injected into each radio button.
+      </td>
+    </tr>
+    <tr>
+      <td>onValueSelect</td>
+      <td>function</td>
+      <td>
+        Callback that is invoked whenever a radio button inside the{" "}
+        <i>RadioGroup</i> is clicked on (given <i> isDisabled</i> is{" "}
+        <i>false</i>). <br /> This callback should receive the newly selected
+        value as its only parameter.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### Extendable styles
+
+<table width="100%">
+  <thead>
+    <tr>
+      <th>Style name</th>
+      <th>@selectors</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>radioGroup</td>
+      <td></td>
+      <td>
+        This style affects the radio buttons' wrapper element. Useful for
+        borders and spacing.
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/src/modules/Radio/RadioGroup.story.tsx
+++ b/src/modules/Radio/RadioGroup.story.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from "react";
+import Radio from "./Radio";
+import RadioGroup from "./RadioGroup";
+
+interface IProps {
+  hasError?: boolean;
+  disabled?: boolean;
+  name: string;
+  selectedValue?: string;
+}
+
+const RadioGroupExample: React.FC<IProps> = ({
+  name,
+  selectedValue,
+  ...props
+}) => {
+  const [selected, setSelected] = useState(selectedValue);
+
+  return (
+    <RadioGroup
+      name={name}
+      selectedValue={selected}
+      onValueSelect={newSelectedValue => setSelected(newSelectedValue)}
+      {...props}
+    >
+      <Radio value={`${name}1`} label="Example Radio 1" />
+      <Radio value={`${name}2`} label="Example Radio 2" />
+      <Radio value={`${name}3`} label="Example Radio 3" />
+    </RadioGroup>
+  );
+};
+
+export { RadioGroupExample };

--- a/src/modules/Radio/RadioGroup.tsx
+++ b/src/modules/Radio/RadioGroup.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { WithStylesProps, ThemeStyleSheetFactory } from "../../types";
+import { withStyles } from "../../base";
+
+interface IProps {
+  children: JSX.Element[];
+  disabled?: boolean;
+  hasError?: boolean;
+  name: string;
+  selectedValue?: string;
+  onValueSelect: (selectedValue: string) => void;
+}
+
+const styleSheet: ThemeStyleSheetFactory = () => ({
+  radioGroup: {
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "space-between"
+  }
+});
+
+const RadioGroup: React.FC<IProps & WithStylesProps> = ({
+  children,
+  cx,
+  styles,
+  ...props
+}) => (
+  <div className={cx(styles.radioGroup)}>
+    {React.Children.map(children, child =>
+      React.cloneElement(child, {
+        ...props
+      })
+    )}
+  </div>
+);
+
+export default withStyles(styleSheet)(RadioGroup);

--- a/src/modules/Radio/index.ts
+++ b/src/modules/Radio/index.ts
@@ -1,0 +1,2 @@
+export { default as Radio } from "./Radio";
+export { default as RadioGroup } from "./RadioGroup";


### PR DESCRIPTION
In this PR we add the Radio module to the Y design, which includes the `Radio` (button) and `RadioGroup` components.

Please check out the storybook for a complete description of the defined API and extendable styles.