### PR TITLE
Feature/Component_registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-is": "^16.12.0",
+    "react-registry": "^0.5.0",
     "react-svg": "^11.0.5",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.1.0",

--- a/src/base/Registry.ts
+++ b/src/base/Registry.ts
@@ -26,8 +26,8 @@ class ComponentRegistry {
     return component;
   }
 
-  static register<T>(
-    component: StyledComponent<T>,
+  static register(
+    component: any,
     componentRegistryId: string,
     params?: Arguments
   ) {

--- a/src/base/Registry.ts
+++ b/src/base/Registry.ts
@@ -1,0 +1,49 @@
+import { Registry } from "react-registry";
+import { Arguments } from "react-registry/dist/util/Arguments";
+import { StyledComponent } from "../types";
+
+class ComponentRegistry {
+  static get<T>(componentRegistryId: string, params?: Arguments) {
+    let getParams: any = {
+      id: componentRegistryId,
+      conditions: { id: componentRegistryId }
+    };
+    if (params && params.isValid()) {
+      getParams = {
+        ...getParams,
+        conditions: { ...getParams.conditions, ...params.conditions },
+        ...params
+      };
+    }
+    const component = Registry.get(getParams) as StyledComponent<T>;
+    if (!component) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `There is no component registered with name ${componentRegistryId}`
+      );
+    }
+
+    return component;
+  }
+
+  static register<T>(
+    component: StyledComponent<T>,
+    componentRegistryId: string,
+    params?: Arguments
+  ) {
+    let registerParams: any = {
+      id: componentRegistryId,
+      conditions: { id: componentRegistryId }
+    };
+    if (params && params.isValid()) {
+      registerParams = {
+        ...registerParams,
+        conditions: { ...registerParams.conditions, ...params.conditions },
+        ...params
+      };
+    }
+    Registry.register(component, registerParams);
+  }
+}
+
+export default ComponentRegistry;

--- a/src/base/index.ts
+++ b/src/base/index.ts
@@ -1,3 +1,4 @@
 export { default as withStyles } from "./withStyles";
 export { default as useStyles } from "./useStyles";
 export { default as useTheme } from "./useTheme";
+export { default as ComponentRegistry } from "./Registry";

--- a/src/base/withStyles.tsx
+++ b/src/base/withStyles.tsx
@@ -100,7 +100,7 @@ function withStyles<Theme = ThemeSheet, T = unknown>(
     };
 
     if (register) {
-      ComponentRegistry.register<Props>(WithStyles, baseName);
+      ComponentRegistry.register(WithStyles, baseName);
     }
 
     return WithStyles;

--- a/src/base/withStyles.tsx
+++ b/src/base/withStyles.tsx
@@ -18,7 +18,7 @@ import ComponentRegistry from "./Registry";
  */
 function withStyles<Theme = ThemeSheet, T = unknown>(
   styleSheet: ThemeStyleSheetFactory<T>,
-  options: WithStylesOptions = { extendable: true, register: true }
+  options: WithStylesOptions = { extendable: true, register: false }
 ) /* infer */ {
   const {
     cxPropName = aesthetic.options.cxPropName,

--- a/src/base/withStyles.tsx
+++ b/src/base/withStyles.tsx
@@ -11,13 +11,14 @@ import {
   WithStylesWrapperProps
 } from "../types";
 import useStyles from "./useStyles";
+import ComponentRegistry from "./Registry";
 
 /**
  * Wrap a React component with an HOC that injects the defined style sheet as a prop.
  */
 function withStyles<Theme = ThemeSheet, T = unknown>(
   styleSheet: ThemeStyleSheetFactory<T>,
-  options: WithStylesOptions = { extendable: true }
+  options: WithStylesOptions = { extendable: true, register: true }
 ) /* infer */ {
   const {
     cxPropName = aesthetic.options.cxPropName,
@@ -25,7 +26,8 @@ function withStyles<Theme = ThemeSheet, T = unknown>(
     extendFrom = "",
     passThemeProp = aesthetic.options.passThemeProp,
     stylesPropName = aesthetic.options.stylesPropName,
-    themePropName = aesthetic.options.themePropName
+    themePropName = aesthetic.options.themePropName,
+    register
   } = options;
 
   return function withStylesComposer<Props extends object = {}>(
@@ -96,6 +98,10 @@ function withStyles<Theme = ThemeSheet, T = unknown>(
         extendFrom: styleName
       })(WrappedComponent);
     };
+
+    if (register) {
+      ComponentRegistry.register<Props>(WithStyles, baseName);
+    }
 
     return WithStyles;
   };

--- a/src/base/withStyles.tsx
+++ b/src/base/withStyles.tsx
@@ -1,14 +1,15 @@
 import React from "react";
-import aesthetic, { ThemeSheet } from "aesthetic";
+import aesthetic from "aesthetic";
 import hoistNonReactStatics from "hoist-non-react-statics";
 import uuid from "uuid/v4";
 import deepMerge from "extend";
-import { StyledComponent } from "aesthetic-react";
 import {
   ThemeStyleSheetFactory,
   WithStylesProps,
   WithStylesOptions,
-  WithStylesWrapperProps
+  WithStylesWrapperProps,
+  StyledComponent,
+  ThemeSheet
 } from "../types";
 import useStyles from "./useStyles";
 import ComponentRegistry from "./Registry";

--- a/src/hooks/useRegistry.ts
+++ b/src/hooks/useRegistry.ts
@@ -15,7 +15,7 @@ export function useRegistryWithStyles<T>(
   styleSheet: ThemeStyleSheetFactory
 ) {
   return useMemo(() => {
-    const component = ComponentRegistry.get<BaseChipProps>(componentRegistryId);
+    const component = ComponentRegistry.get<T>(componentRegistryId);
     if (styleSheet) {
       return component.extendStyles(styleSheet);
     }

--- a/src/hooks/useRegistry.ts
+++ b/src/hooks/useRegistry.ts
@@ -1,0 +1,27 @@
+import { useMemo } from "react";
+import { ThemeStyleSheetFactory } from "../types";
+import { ComponentRegistry } from "../base";
+import { IProps as BaseChipProps } from "../modules/Chip/BaseChip";
+
+export function useRegistry<T>(
+  componentRegistryId: string
+) {
+  return useMemo(() => ComponentRegistry.get<T>(componentRegistryId), [componentRegistryId]);
+}
+
+
+export function useRegistryWithStyles<T>(
+  componentRegistryId: string,
+  styleSheet: ThemeStyleSheetFactory
+) {
+  return useMemo(() => {
+    const component = ComponentRegistry.get<BaseChipProps>(componentRegistryId);
+    if (styleSheet) {
+      return component.extendStyles(styleSheet);
+    }
+    return component;
+  }, [componentRegistryId,styleSheet]);
+}
+
+
+export default useRegistryWithStyles;

--- a/src/modules/Chip/BaseChip.tsx
+++ b/src/modules/Chip/BaseChip.tsx
@@ -74,4 +74,4 @@ const BaseChip: React.FC<IProps & WithStylesProps> = ({
     </div>
   );
 };
-export default withStyles(styleSheet)(BaseChip);
+export default withStyles(styleSheet, { register: true })(BaseChip);

--- a/src/modules/Chip/CloseableChip.tsx
+++ b/src/modules/Chip/CloseableChip.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { Theme, WithStylesProps, ThemeStyleSheetFactory } from "../../types";
-import BaseChip, { IProps as BaseChipProps } from "./BaseChip";
+import { IProps as BaseChipProps } from "./BaseChip";
 import { Icon } from "../Icon";
 import { withStyles } from "../../base";
+import useRegistryWithStyles from "../../hooks/useRegistry";
 
 export interface IProps extends BaseChipProps {
   onClose: () => void;
@@ -23,15 +24,17 @@ const styleSheet: ThemeStyleSheetFactory = (theme: Theme) => ({
   }
 });
 
-export const CloseableChipStyle = BaseChip.extendStyles(styleSheet);
-
-const CloseableChipComponent: React.FC<IProps & WithStylesProps> = ({
+const CloseableChip: React.FC<IProps & WithStylesProps> = ({
   onClose = () => {},
   renderRightIcon,
   styles,
   cx,
   ...props
 }) => {
+  const CloseableChipStyle = useRegistryWithStyles<IProps>(
+    "BaseChip",
+    styleSheet
+  );
   return (
     <CloseableChipStyle
       {...props}
@@ -54,4 +57,4 @@ const CloseableChipComponent: React.FC<IProps & WithStylesProps> = ({
   );
 };
 
-export default withStyles(styleSheet)(CloseableChipComponent);
+export default withStyles(styleSheet)(CloseableChip);

--- a/src/modules/Chip/CloseableChip.tsx
+++ b/src/modules/Chip/CloseableChip.tsx
@@ -31,7 +31,7 @@ const CloseableChip: React.FC<IProps & WithStylesProps> = ({
   cx,
   ...props
 }) => {
-  const CloseableChipStyle = useRegistryWithStyles<IProps>(
+  const CloseableChipStyle = useRegistryWithStyles<BaseChipProps>(
     "BaseChip",
     styleSheet
   );

--- a/src/modules/Chip/CloseableChip.tsx
+++ b/src/modules/Chip/CloseableChip.tsx
@@ -57,4 +57,4 @@ const CloseableChip: React.FC<IProps & WithStylesProps> = ({
   );
 };
 
-export default withStyles(styleSheet)(CloseableChip);
+export default withStyles(styleSheet, { register: true })(CloseableChip);

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,9 @@ import {
 } from "aesthetic-react";
 import {
   StyleSheetFactory as AesStyleSheetFactory,
-  StyleSheet as AesStyleSheet
+  StyleSheet as AesStyleSheet,
+  ThemeSheet as AesThemeSheet,
+  StyleName as AesStyleName
 } from "aesthetic";
 import { defaultPalette } from "./tokens";
 
@@ -69,9 +71,23 @@ export type Theme = {
   };
 };
 
+export type ThemeSheet = AesThemeSheet;
+
 export type StyleSheet = AesStyleSheet;
 
-export type StyledComponent<Props> = AesStyledComponent<Props>;
+export type StyleName = AesStyleName;
+
+// eslint-disable-next-line @typescript-eslint/interface-name-prefix
+export interface StyledComponent<Props>
+  extends React.NamedExoticComponent<Props> {
+  displayName: string;
+  styleName: StyleName;
+  WrappedComponent: React.ComponentType<any>;
+  extendStyles<T>(
+    styleSheet: ThemeStyleSheetFactory<T>,
+    extendOptions?: Omit<WithStylesOptions, "extendFrom">
+  ): StyledComponent<Props>;
+}
 
 export type WithStylesOptions = AesWithStylesOptions & { register: boolean };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,6 @@ import {
   WithThemeWrapperProps,
   WithStylesWrapperProps as AesWithStylesWrapperProps,
   WithStylesOptions as AesWithStylesOptions,
-  StyledComponent as AesStyledComponent
 } from "aesthetic-react";
 import {
   StyleSheetFactory as AesStyleSheetFactory,

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,15 +14,19 @@ import {
 import { defaultPalette } from "./tokens";
 
 export enum FontWeight {
-  REGULAR= 400,
-  MEDIUM= 500,
-  BOLD= 700,
-  BOLDER= 900
+  REGULAR = 400,
+  MEDIUM = 500,
+  BOLD = 700,
+  BOLDER = 900
 }
 
 interface IFont {
   fontSize: string | number;
-  fontWeight: FontWeight.REGULAR | FontWeight.MEDIUM | FontWeight.BOLD | FontWeight.BOLDER;
+  fontWeight:
+    | FontWeight.REGULAR
+    | FontWeight.MEDIUM
+    | FontWeight.BOLD
+    | FontWeight.BOLDER;
   lineHeight: string | number;
   fontFamily: string;
   letterSpacing: string;
@@ -69,7 +73,7 @@ export type StyleSheet = AesStyleSheet;
 
 export type StyledComponent<Props> = AesStyledComponent<Props>;
 
-export type WithStylesOptions = AesWithStylesOptions;
+export type WithStylesOptions = AesWithStylesOptions & { register: boolean };
 
 export type StyleSheetFactory<
   ThemeSheet = Theme,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2040,9 +2040,9 @@
     "@babel/runtime" "^7.7.7"
 
 "@testing-library/dom@^6.11.0":
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-6.11.0.tgz#962a38f1a721fdb7c9e35e7579e33ff13a00eda4"
-  integrity sha512-Pkx9LMIGshyNbfmecjt18rrAp/ayMqGH674jYER0SXj0iG9xZc+zWRjk2Pg9JgPBDvwI//xGrI/oOQkAi4YEew==
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-6.12.0.tgz#0e40efd58d85d92ad9c39ef7667952195e835bbf"
+  integrity sha512-OMZgdsqwRICjfX8gzMcIdB3jFYiPKX25SaOHeq7zh3l9+MxpVj2fpk/LicL79L8t6LG7kY69YL4Y0kbdj5Yx1Q==
   dependencies:
     "@babel/runtime" "^7.6.2"
     "@sheerun/mutationobserver-shim" "^0.3.2"
@@ -2160,9 +2160,9 @@
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/node@*":
-  version "13.5.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.5.0.tgz#4e498dbf355795a611a87ae5ef811a8660d42662"
-  integrity sha512-Onhn+z72D2O2Pb2ql2xukJ55rglumsVo1H6Fmyi8mlU9SvKdBk/pUSUAiBY/d9bAOF7VVWajX3sths/+g6ZiAQ==
+  version "13.5.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.5.1.tgz#6fae50892d1841f4b38b298e2f78fb68c5960cb9"
+  integrity sha512-Jj2W7VWQ2uM83f8Ls5ON9adxN98MvyJsMSASYFuSvrov8RMRY64Ayay7KV35ph1TSGIJ2gG9ZVDdEq3c3zaydA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -2259,11 +2259,9 @@
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
 "@types/uuid@^3.4.6":
-  version "3.4.6"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.6.tgz#d2c4c48eb85a757bf2927f75f939942d521e3016"
-  integrity sha512-cCdlC/1kGEZdEglzOieLDYBxHsvEOIg7kp/2FYyVR9Pxakq+Qf/inL3RKQ+PA8gOlI/NnL+fXmQH12nwcGzsHw==
-  dependencies:
-    "@types/node" "*"
+  version "3.4.7"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.7.tgz#51d42247473bc00e38cc8dfaf70d936842a36c03"
+  integrity sha512-C2j2FWgQkF1ru12SjZJyMaTPxs/f6n90+5G5qNakBxKXjTBc/YTSelHh4Pz1HUDwxFXD9WvpQhOGCDC+/Y4mIQ==
 
 "@types/webpack-env@^1.15.0":
   version "1.15.0"
@@ -2276,40 +2274,40 @@
   integrity sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==
 
 "@types/yargs@^13.0.0":
-  version "13.0.6"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.6.tgz#6aed913a92c262c13b94d4bca8043237de202124"
-  integrity sha512-IkltIncDQWv6fcAvnHtJ6KtkmY/vtR3bViOaCzpj/A3yNhlfZAgxNe6AEQD1cQrkYD+YsKVo08DSxvNKEsD7BA==
+  version "13.0.7"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.7.tgz#658d8578a444670a41cc9c338d5e0e0a9910fd9e"
+  integrity sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==
   dependencies:
     "@types/yargs-parser" "*"
 
 "@typescript-eslint/eslint-plugin@^2.7.0":
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.17.0.tgz#880435a9f9bdd50b45fa286ba63fed723d73c837"
-  integrity sha512-tg/OMOtPeXlvk0ES8mZzEZ4gd1ruSE03nsKcK+teJhxYv5CPCXK6Mb/OK6NpB4+CqGTHs4MVeoSZXNFqpT1PyQ==
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.18.0.tgz#f8cf272dfb057ecf1ea000fea1e0b3f06a32f9cb"
+  integrity sha512-kuO8WQjV+RCZvAXVRJfXWiJ8iYEtfHlKgcqqqXg9uUkIolEHuUaMmm8/lcO4xwCOtaw6mY0gStn2Lg4/eUXXYQ==
   dependencies:
-    "@typescript-eslint/experimental-utils" "2.17.0"
+    "@typescript-eslint/experimental-utils" "2.18.0"
     eslint-utils "^1.4.3"
     functional-red-black-tree "^1.0.1"
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.17.0":
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.17.0.tgz#12ed4a5d656e02ff47a93efc7d1ce1b8f1242351"
-  integrity sha512-2bNf+mZ/3mj5/3CP56v+ldRK3vFy9jOvmCPs/Gr2DeSJh+asPZrhFniv4QmQsHWQFPJFWhFHgkGgJeRmK4m8iQ==
+"@typescript-eslint/experimental-utils@2.18.0":
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.18.0.tgz#e4eab839082030282496c1439bbf9fdf2a4f3da8"
+  integrity sha512-J6MopKPHuJYmQUkANLip7g9I82ZLe1naCbxZZW3O2sIxTiq/9YYoOELEKY7oPg0hJ0V/AQ225h2z0Yp+RRMXhw==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.17.0"
+    "@typescript-eslint/typescript-estree" "2.18.0"
     eslint-scope "^5.0.0"
 
 "@typescript-eslint/parser@^2.13.0", "@typescript-eslint/parser@^2.3.0":
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.17.0.tgz#627f79586d868edbab55f46a6b183cdc341aea1d"
-  integrity sha512-k1g3gRQ4fwfJoIfgUpz78AovicSWKFANmvTfkAHP24MgJHjWfZI6ya7tsQZt1sLczvP4G9BE5G5MgADHdmJB/w==
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.18.0.tgz#d5f7fc1839abd4a985394e40e9d2454bd56aeb1f"
+  integrity sha512-SJJPxFMEYEWkM6pGfcnjLU+NJIPo+Ko1QrCBL+i0+zV30ggLD90huEmMMhKLHBpESWy9lVEeWlQibweNQzyc+A==
   dependencies:
     "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "2.17.0"
-    "@typescript-eslint/typescript-estree" "2.17.0"
+    "@typescript-eslint/experimental-utils" "2.18.0"
+    "@typescript-eslint/typescript-estree" "2.18.0"
     eslint-visitor-keys "^1.1.0"
 
 "@typescript-eslint/typescript-estree@2.11.0":
@@ -2325,10 +2323,10 @@
     semver "^6.3.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/typescript-estree@2.17.0":
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.17.0.tgz#2ce1531ec0925ef8d22d7026235917c2638a82af"
-  integrity sha512-g0eVRULGnEEUakxRfJO0s0Hr1LLQqsI6OrkiCLpdHtdJJek+wyd8mb00vedqAoWldeDcOcP8plqw8/jx9Gr3Lw==
+"@typescript-eslint/typescript-estree@2.18.0":
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.18.0.tgz#cfbd16ed1b111166617d718619c19b62764c8460"
+  integrity sha512-gVHylf7FDb8VSi2ypFuEL3hOtoC4HkZZ5dOjXvVjoyKdRrvXAOPSzpNRnKMfaUUEiSLP8UF9j9X9EDLxC0lfZg==
   dependencies:
     debug "^4.1.1"
     eslint-visitor-keys "^1.1.0"
@@ -4696,9 +4694,9 @@ classnames@^2.2.5:
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
 clean-css@^4.1.11, clean-css@^4.2.1:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.2.tgz#8519abda724b3e759bc79d196369906925d81a3f"
-  integrity sha512-yKycArwReQXbOD/3pmsPmt6p7oUBww8MisDabL2pCUWkbVONvCJoBdCjgY4ZVQmKX5juz/JB9oDcP6XzGUpjwQ==
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.3.tgz#507b5de7d97b48ee53d84adb0160ff6216380f78"
+  integrity sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==
   dependencies:
     source-map "~0.6.0"
 
@@ -5388,9 +5386,9 @@ d@1, d@^1.0.1:
     type "^1.0.1"
 
 damerau-levenshtein@^1.0.4:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz#780cf7144eb2e8dbd1c3bb83ae31100ccc31a414"
-  integrity sha512-CBCRqFnpu715iPmw1KrdOrzRqbdFwQTwAWyyyYS42+iAgHCuXZ+/TdMgQkUENPomxEz9z1BEzuQU2Xw0kUuAgA==
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz#143c1641cb3d85c60c32329e26899adea8701791"
+  integrity sha512-JVrozIeElnj3QzfUIt8tB8YMluBJom4Vw9qTPpjGYQ9fYlB3D/rb6OordUxf3xeFB35LKWs0xqcO5U6ySvBtug==
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -5893,9 +5891,9 @@ ejs@^2.7.4:
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
 electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.338:
-  version "1.3.340"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.340.tgz#5d4fe78e984d4211194cf5a52e08069543da146f"
-  integrity sha512-hRFBAglhcj5iVYH+o8QU0+XId1WGoc0VGowJB1cuJAt3exHGrivZvWeAO5BRgBZqwZtwxjm8a5MQeGoT/Su3ww==
+  version "1.3.341"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.341.tgz#ad4c039bf621715a12dd814a95a7d89ec80b092c"
+  integrity sha512-iezlV55/tan1rvdvt7yg7VHRSkt+sKfzQ16wTDqTbQqtl4+pSUkKPXpQHDvEt0c7gKcUHHwUbffOgXz6bn096g==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -6141,9 +6139,9 @@ eslint-config-airbnb@^18.0.1:
     object.entries "^1.1.0"
 
 eslint-config-prettier@^6.9.0:
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.9.0.tgz#430d24822e82f7deb1e22a435bfa3999fae4ad64"
-  integrity sha512-k4E14HBtcLv0uqThaI6I/n1LEqROp8XaPu6SO9Z32u5NlGRC07Enu1Bh2KEFw4FNHbekH8yzbIU9kUGxbiGmCA==
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz#7b15e303bf9c956875c948f6b21500e48ded6a7f"
+  integrity sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==
   dependencies:
     get-stdin "^6.0.0"
 
@@ -6845,7 +6843,7 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b"
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
 
-flow-parser@0.*
+flow-parser@0.*:
   version "0.117.0"
   resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.117.0.tgz#0a8925c8d00959081e6a1547aa3ce015d88f3ab9"
   integrity sha512-B9wlFfFtE9R9+lvhfShHIuE1eGLfTmMDUxIBU3NfbVynVzB2LNT38A5xBUURW5AYlkJveIlCcEsouOsro/DNWg==
@@ -6854,11 +6852,6 @@ flow-parser@0.116.1:
   version "0.116.1"
   resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.116.1.tgz#2cded960269f702552feb5419c57c7c146ba171e"
   integrity sha512-uMbaTjiMhBKa/il1esHyWyVVWfrWdG/eLmG62MQulZ59Yghpa30H1tmukFZLptsBafZ8ddiPyf7I+SiA+euZ6A==
-
-flow-parser@0.116.0:
-  version "0.116.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.116.0.tgz#7c08e4559a37863d95870e3ffb5523c5fc3525b1"
-  integrity sha512-sHiUjYI9U7H94diCN8BdzwYFJIkyCy2GN73UDFbKHTIuLdfROfZZwD6jAv2qWMl7lcPrBK9YAVeArLLbekxVeg==
 
 flush-write-stream@^1.0.0:
   version "1.1.1"
@@ -8207,6 +8200,11 @@ is-directory@^0.3.1:
   resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
   integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
 
+is-docker@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.0.0.tgz#2cb0df0e75e2d064fe1864c37cdeacb7b2dcf25b"
+  integrity sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==
+
 is-dom@^1.0.9:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-dom/-/is-dom-1.1.0.tgz#af1fced292742443bb59ca3f76ab5e80907b4e8a"
@@ -8527,7 +8525,7 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
-is-wsl@^2.1.0:
+is-wsl@^2.1.0, is-wsl@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.1.1.tgz#4a1c152d429df3d441669498e2486d3596ebaf1d"
   integrity sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==
@@ -8715,6 +8713,14 @@ jest-worker@^24.9.0:
   dependencies:
     merge-stream "^2.0.0"
     supports-color "^6.1.0"
+
+jest-worker@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-25.1.0.tgz#75d038bad6fdf58eba0d2ec1835856c497e3907a"
+  integrity sha512-ZHhHtlxOWSxCoNOKHGbiLzXnl42ga9CxDr27H36Qn+15pQZd3R/F24jrmjDelw9j/iHUIWMWs08/u2QN50HHOg==
+  dependencies:
+    merge-stream "^2.0.0"
+    supports-color "^7.0.0"
 
 js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.5.1"
@@ -9032,9 +9038,9 @@ leven@^2.1.0:
   integrity sha1-wuep93IJTe6dNCAq6KzORoeHVYA=
 
 levenary@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/levenary/-/levenary-1.1.0.tgz#fc146fe75f32dc483a0a2c64aef720f602cd6210"
-  integrity sha512-VHcwhO0UTpUW7rLPN2/OiWJdgA1e9BqEDALhrgCe/F+uUJnep6CoUsTzMeP8Rh0NGr9uKquXxqe7lwLZo509nQ==
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/levenary/-/levenary-1.1.1.tgz#842a9ee98d2075aa7faeedbe32679e9205f46f77"
+  integrity sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==
   dependencies:
     leven "^3.1.0"
 
@@ -9237,6 +9243,11 @@ lodash.uniq@4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
+
+lodash@4.17.10:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+  integrity sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==
 
 lodash@4.17.15, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@~4.17.10:
   version "4.17.15"
@@ -10411,11 +10422,12 @@ open@^6.3.0:
     is-wsl "^1.1.0"
 
 open@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/open/-/open-7.0.0.tgz#7e52999b14eb73f90f0f0807fe93897c4ae73ec9"
-  integrity sha512-K6EKzYqnwQzk+/dzJAQSBORub3xlBTxMz+ntpZpH/LyCa1o6KjXhuN+2npAaI9jaSmU3R1Q8NWf4KUWcyytGsQ==
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.0.1.tgz#259a6c2097da6b95c596a2734f2ed05643c432b8"
+  integrity sha512-/fVm742AZt6bZ3NpbmBzGpZksDiGbo+xz8RylegKSAnTCgT5u5tvJe0cre3QxICphqHhJHc0OFtFyvU7rNx8+Q==
   dependencies:
-    is-wsl "^2.1.0"
+    is-docker "^2.0.0"
+    is-wsl "^2.1.1"
 
 opencollective-postinstall@^2.0.2:
   version "2.0.2"
@@ -10538,7 +10550,7 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
-p-limit@^2.0.0, p-limit@^2.2.0:
+p-limit@^2.0.0, p-limit@^2.2.0, p-limit@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.2.tgz#61279b67721f5287aa1c13a9a7fbbc48c9291b1e"
   integrity sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==
@@ -10606,9 +10618,9 @@ package-json@^4.0.0:
     semver "^5.1.0"
 
 pako@~1.0.5:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
-  integrity sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
 parallel-transform@^1.1.0:
   version "1.2.0"
@@ -10919,9 +10931,9 @@ pnp-webpack-plugin@1.5.0:
     ts-pnp "^1.1.2"
 
 polished@^3.3.1:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/polished/-/polished-3.4.3.tgz#9b2580a3ead4ef2e030265c3eccbc06a2b68a049"
-  integrity sha512-EcA6RleHgFalVDZg5djztOyraWOkZcFSNwDCASkq6MZf68B+QlciKWRiNJn5sUDtwOLrk/xbqgvxoTfMjazvuw==
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-3.4.4.tgz#ac8cd6e704887398f3b802718f9d389b9ea4307b"
+  integrity sha512-x9PKeExyI9AhWrJP3Q57I1k7GInujjiVBJMPFmycj9hX1yCOo/X9eu9eZwxgOziiXge3WbFQ5XOmkzunOntBSA==
   dependencies:
     "@babel/runtime" "^7.6.3"
 
@@ -11790,6 +11802,13 @@ react-popper@^1.3.6:
     typed-styles "^0.0.7"
     warning "^4.0.2"
 
+react-registry@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/react-registry/-/react-registry-0.5.0.tgz#6020184025e83b871b36287fe27244cbbd56b345"
+  integrity sha512-zCo3PObNs5HgqkjVrHax4Uj2iu2mBVLvupCx5fl3TFKAnvPQ8ufX6cY7ToInSDFHykDSld9rB3HgTNdKt5OKRQ==
+  dependencies:
+    lodash "4.17.10"
+
 react-sizeme@^2.6.7:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/react-sizeme/-/react-sizeme-2.6.12.tgz#ed207be5476f4a85bf364e92042520499455453e"
@@ -11801,9 +11820,9 @@ react-sizeme@^2.6.7:
     throttle-debounce "^2.1.0"
 
 react-svg@^11.0.5:
-  version "11.0.8"
-  resolved "https://registry.yarnpkg.com/react-svg/-/react-svg-11.0.8.tgz#33ce1f7b493c8997fd5633756af4ea528b073570"
-  integrity sha512-YcxY8JQWNAJttyXzDfhqkIDyESzQjP2UOn8GNwNLqdqsS6TMDjHI2TOBSvlvFxoEOv5i00cmjnsenNm2NCk2SA==
+  version "11.0.9"
+  resolved "https://registry.yarnpkg.com/react-svg/-/react-svg-11.0.9.tgz#0387c95bce583922ae84035ad7596bcafaffbb91"
+  integrity sha512-MHgMF6JDz7FBUXry3ynyQTxxMnd5HISlVWSXP6qpcNtXZ5Z4Zp9n/0wS2WPnKp8zLguy+C7LK1R/n2b27tj5uQ==
   dependencies:
     "@babel/runtime" "^7.8.3"
     "@tanem/svg-injector" "^8.0.39"
@@ -12475,9 +12494,9 @@ rimraf@2.6.3, rimraf@~2.6.2:
     glob "^7.1.3"
 
 rimraf@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.0.tgz#614176d4b3010b75e5c390eb0ee96f6dc0cebb9b"
-  integrity sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.1.tgz#48d3d4cb46c80d388ab26cd61b1b466ae9ae225a"
+  integrity sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==
   dependencies:
     glob "^7.1.3"
 
@@ -12588,9 +12607,9 @@ rollup-pluginutils@^2.6.0, rollup-pluginutils@^2.8.1, rollup-pluginutils@^2.8.2:
     estree-walker "^0.6.1"
 
 rollup@^1.29.0:
-  version "1.30.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.30.0.tgz#ae9c893804e8eaa8f8f74b0aaf7e7fb4374a9d01"
-  integrity sha512-ANcmfaSQwpcJtZUTA0ZMNBtFcQ1B4A5FldlNqEK0WdWm9sHSKu93ffa2KV1ux8HA/yKIV/ZARV28m7rNdXJgEw==
+  version "1.30.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.30.1.tgz#3fd28d6198beb2f3cd1640732047d5ec16c2d3a0"
+  integrity sha512-Uus8mwQXwaO+ZVoNwBcXKhT0AvycFCBW/W8VZtkpVGsotRllWk9oldfCjqWmTnFRI0y7x6BnEqSqc65N+/YdBw==
   dependencies:
     "@types/estree" "*"
     "@types/node" "*"
@@ -13654,7 +13673,7 @@ supports-color@^6.1.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7.1.0:
+supports-color@^7.0.0, supports-color@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
   integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
@@ -13802,14 +13821,15 @@ terser-webpack-plugin@^1.4.3:
     worker-farm "^1.7.0"
 
 terser-webpack-plugin@^2.1.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-2.3.2.tgz#6d3d1b0590c8f729bfbaeb7fb2528b8b62db4c74"
-  integrity sha512-SmvB/6gtEPv+CJ88MH5zDOsZdKXPS/Uzv2//e90+wM1IHFUhsguPKEILgzqrM1nQ4acRXN/SV4Obr55SXC+0oA==
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-2.3.3.tgz#b89043168bd414153bab86f4362ac23d537b78b0"
+  integrity sha512-gWHkaGzGYjmDoYxksFZynWTzvXOAjQ5dd7xuTMYlv4zpWlLSb6v0QLSZjELzP5dMs1ox30O1BIPs9dgqlMHuLQ==
   dependencies:
     cacache "^13.0.1"
     find-cache-dir "^3.2.0"
-    jest-worker "^24.9.0"
-    schema-utils "^2.6.1"
+    jest-worker "^25.1.0"
+    p-limit "^2.2.2"
+    schema-utils "^2.6.4"
     serialize-javascript "^2.1.2"
     source-map "^0.6.1"
     terser "^4.4.3"
@@ -14135,20 +14155,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.7.4:
-  version "3.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
-  integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
+typescript@3.7.5, typescript@^3.7.4:
+  version "3.7.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
+  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
 typescript@^2.1.4:
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
   integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
-
-typescript@^3.7.4:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
 typings-core@^2.3.3:
   version "2.3.3"


### PR DESCRIPTION
Using Component Registry so we can keep hierarchy when going to another projects.

## Installation 
Package used: _react-registry_

## How it works?

The user registers the component with an Id and instead of importing it from the file, he should import it from the registry.

```typescript
// Register
const StyledBaseChip = withStyles(styleSheet)(BaseChip);
ComponentRegistry.register(StyledBaseChip, "BaseChip");

// Get
const component = ComponentRegistry.get<BaseChipProps>("BaseChip");
component.extendStyles(styleSheet);
```

## Simplified

_withStyles_ and _extendStyles_ will automatically register the component with the **displayName** if register parameter is passed.
```typescript
 export default withStyles(styleSheet, {register: true})(BaseChip);
```
would automatically register it as "BaseChip".

To access the parent component inside your current component, you can use the get method of the registry, but you can also use the custom hook _useRegistry_ or _useRegistryWithStyles_

```typescript
  const CloseableChipStyle = useRegistryWithStyles<BaseChipProps>(
    "BaseChip",
    styleSheet
  );
```


## On Future Solutions

```typescript
import {BaseChip as BaseChipDiana} from "@henrts/diana";
export const BaseChip = BaseChipDiana.extendStyles(() => ({chip:{backgroundColor:"green"}});

// ---- or ----

const BaseChipDiana = ComponentRegistry.get<IProps>("BaseChip");
export const BaseChip = BaseChipDiana.extendStyles(() => ({chip:{backgroundColor:"green"}});
```

Will automatically register the new BaseChip and it will be reused along all the DDM app, as long as you keep getting it from the registry.

## Need to make more checks as the application grows

I don't think it is needed to get from the registry on the DDM, it seems to work if you import from file, because it will be registered again, and the hook will use it