### PR TITLE
[Proposal] - Aditional Styles 

### DIFF
--- a/src/modules/Button/BaseButton.tsx
+++ b/src/modules/Button/BaseButton.tsx
@@ -19,10 +19,12 @@ const styleSheet: ThemeStyleSheetFactory = theme => ({
     cursor: "pointer",
     outlineStyle: "none",
     display: "flex",
-    alignItems: "center"
+    alignItems: "center",
+    "@selectors": {
+      "&.disabled": {},
+      "&.danger": {}
+    }
   },
-  danger: {},
-  disabled: {},
   buttonText: {}
 });
 
@@ -36,14 +38,14 @@ const BaseButton: React.FC<IProps & WithStylesProps> = ({
   renderRightIcon,
   wrappedRef,
   parentStylesheet,
+  aditionalStyles = [],
   ...props
 }) => {
   const { disabled } = props;
-  const styleArray = [danger && styles.danger, disabled && styles.disabled];
-
+  const styleArray = [danger && "danger", disabled && "disabled"];
   return (
     <button
-      className={cx(styles.button, ...styleArray, className)}
+      className={cx(styles.button, ...styleArray, ...aditionalStyles)}
       type="submit"
       {...props}
       ref={wrappedRef}
@@ -54,11 +56,5 @@ const BaseButton: React.FC<IProps & WithStylesProps> = ({
     </button>
   );
 };
-
-// const ForwardedButton = React.forwardRef<
-//   IProps & WithStylesProps,
-//   HTMLButtonElement
-// >((props: any, ref) => <BaseButton wrappedRef={ref} {...props} />);
-// ForwardedButton.displayName = "BaseButton";
 
 export default withStyles(styleSheet)(BaseButton);

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,10 @@ export type StyledComponent<Props> = AesStyledComponent<Props>;
 
 export type WithStylesOptions = AesWithStylesOptions;
 
+export interface IWithAditionalStylesProps {
+  aditionalStyles?: AesWithStylesOptions[]
+}
+
 export type StyleSheetFactory<
   ThemeSheet = Theme,
   T = unknown
@@ -78,7 +82,8 @@ export type StyleSheetFactory<
 export type ThemeStyleSheetFactory<T = unknown> = StyleSheetFactory<Theme, T>;
 
 export type WithStylesProps = WithStylesWrappedProps<Theme> &
-  WithStylesWrapperProps;
+  WithStylesWrapperProps & IWithAditionalStylesProps;
+  
 export type WithThemeProps = WithThemeWrappedProps<Theme> &
   WithThemeWrapperProps;
 


### PR DESCRIPTION
This small change allows a developer to add aditional styles to a expanded wrapped component.  

This is possible by adding to the WithStylesProp the interface `IWithAditionalStylesProps`

```typescript
export interface IWithAditionalStylesProps {
  aditionalStyles?: AesWithStylesOptions[]
}
```

Using the example of `BaseButton`, if I want to expand this to create a derivative that supports an "Active"/"Toggled" state, I can do:

```typescript
const stylesheet: StyleSheetFactory<Theme> = (theme: Theme) => ({
 active: {
    border: "1px solid #ccc",
    color: "black"
 }
});
```
and then:

```typescript
const DerivateButton = BaseButton.extendStyles();
export const ActiveButton: React.FC<PropsWithChildren<IActiveButtonProps & WithStylesProps>> 
= ({ children, active, cx, styles, ...props }) => (
<DerivateButton aditionalStyles={[active && styles.active]} {...props}>
{children}
</DerivateButton>
}
```
