### PR TITLE
fix(types/package.json): types wasn't generating lib/module dir

### DIFF
--- a/modules/types/package.json
+++ b/modules/types/package.json
@@ -1,12 +1,20 @@
 {
   "name": "@diana-ui/types",
   "version": "0.0.5",
-  "main": "types.ts",
-  "type": "types.ts",
+  "main": "lib/types.ts",
+  "module": "module/types.ts",
   "license": "MIT",
   "files": [
-    "types.ts"
+    "lib",
+    "module"
   ],
+  "scripts": {
+    "build": "yarn compile:lib && yarn compile:module",
+    "compile:lib": "tsc --target es5 --module es2015 --outDir lib",
+    "compile:module": "tsc --target es6 --module esnext --outDir module",
+    "clean:files": "rimraf lib module",
+    "prepare": "yarn clean:files && yarn build"
+  },
   "devDependencies": {
     "typescript": "^3.7.5"
   },

--- a/modules/types/tsconfig.json
+++ b/modules/types/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As per title.

## Motivation and Context

Problem was detected when integrating ddm onto dmbuddy-frontend. 
Error was that loader couldn't compile .ts type file.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
