### PR TITLE
feat(multidropdown.tsx): added some logical to select all button

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
     "prettier/@typescript-eslint"
   ],
   rules: {
+    "consistent-return": "off",
     "no-underscore-dangle": "off",
     "no-trailing-spaces": "error",
     "arrow-parens": ["error", "as-needed"],

--- a/modules/dropdown/BaseMultipleDropdown.tsx
+++ b/modules/dropdown/BaseMultipleDropdown.tsx
@@ -22,6 +22,7 @@ export interface IBaseMultipleDropdownOptions {
   onItemClicked: (item: IItem, selectedItems: IItem[]) => void;
   onAllButtonClicked: () => void;
   isAllButtonChecked: boolean;
+  onClose?: () => void;
 }
 
 export const styleSheetPopover: ThemeStyleSheetFactory = () => ({
@@ -53,7 +54,8 @@ const BaseMultipleDropdown: React.FC<IBaseMultipleDropdownProps> = props => {
     wrappedRef,
     isAllButtonChecked,
     onItemClicked,
-    onAllButtonClicked
+    onAllButtonClicked,
+    onClose
   } = props;
 
   const ref = usePopoverRef(wrappedRef);
@@ -88,6 +90,7 @@ const BaseMultipleDropdown: React.FC<IBaseMultipleDropdownProps> = props => {
         disabled={disabled || items.length === 0}
         {...props}
         renderHeader={renderCustomHeader}
+        onHide={onClose}
       >
         <ul className={cx(styles.list)}>
           <li

--- a/modules/dropdown/BaseMultipleDropdown.tsx
+++ b/modules/dropdown/BaseMultipleDropdown.tsx
@@ -99,7 +99,7 @@ const BaseMultipleDropdown: React.FC<IBaseMultipleDropdownProps> = props => {
               styles.itemAll,
               isAllButtonChecked && styles.itemSelected
             )}
-            onClick={() => onAllButtonClicked()}
+            onClick={onAllButtonClicked}
             role="presentation"
           >
             {selectAllItem?.(isAllButtonChecked) ?? selectAllText}

--- a/modules/dropdown/BaseMultipleDropdown.tsx
+++ b/modules/dropdown/BaseMultipleDropdown.tsx
@@ -25,6 +25,15 @@ export interface IBaseMultipleDropdownOptions {
   onClose?: () => void;
 }
 
+export interface IRenderItem<T extends IItem> {
+  renderItem?: (
+    item: T,
+    selected: boolean,
+    isAllSelected: boolean,
+    index?: number
+  ) => React.ReactNode;
+}
+
 export const styleSheetPopover: ThemeStyleSheetFactory = () => ({
   container: {
     maxWidth: "100%",
@@ -32,11 +41,16 @@ export const styleSheetPopover: ThemeStyleSheetFactory = () => ({
   }
 });
 
-export type IBaseMultipleDropdownProps = PropsWithChildren<
-  IMultipleProps<IItem> & WithStylesProps & IBaseMultipleDropdownOptions
+export type IBaseMultipleDropdownProps<T extends IItem> = PropsWithChildren<
+  IMultipleProps<IItem> &
+    WithStylesProps &
+    IBaseMultipleDropdownOptions &
+    IRenderItem<T>
 >;
 
-const BaseMultipleDropdown: React.FC<IBaseMultipleDropdownProps> = props => {
+const BaseMultipleDropdown: React.FC<IBaseMultipleDropdownProps<
+  IItem
+>> = props => {
   const {
     className,
     disabled,

--- a/modules/dropdown/Dropdown.story.mdx
+++ b/modules/dropdown/Dropdown.story.mdx
@@ -1,6 +1,10 @@
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
 import LinkTo from "@storybook/addon-links/react";
-import { DropdownStory, MultipleDropdownStory } from "./Dropdown.story.tsx";
+import {
+  DropdownStory,
+  SimpleMultipleDropdownStory,
+  FilterMultipleDropdownStory
+} from "./Dropdown.story.tsx";
 
 <Meta title="Components | Dropdown" />
 
@@ -14,11 +18,19 @@ This component can be used to select a value from a list. It uses the `Popover` 
   </Story>
 </Preview>
 
-### Multiple Dropdown
+### Multiple Dropdown (Normal Mode)
 
 <Preview>
-  <Story name="Multiple Dropdown">
-    <MultipleDropdownStory />
+  <Story name="Multiple Dropdown Simple">
+    <SimpleMultipleDropdownStory />
+  </Story>
+</Preview>
+
+### Multiple Dropdown (Filters Mode)
+
+<Preview>
+  <Story name="Multiple Dropdown Filter">
+    <FilterMultipleDropdownStory />
   </Story>
 </Preview>
 

--- a/modules/dropdown/Dropdown.story.mdx
+++ b/modules/dropdown/Dropdown.story.mdx
@@ -20,7 +20,7 @@ This component can be used to select a value from a list. It uses the `Popover` 
 
 ### Multiple Dropdown (Normal Mode)
 
-<Preview>
+<Preview style={{ height: "250px" }}>
   <Story name="Multiple Dropdown Simple">
     <SimpleMultipleDropdownStory />
   </Story>
@@ -28,7 +28,7 @@ This component can be used to select a value from a list. It uses the `Popover` 
 
 ### Multiple Dropdown (Filters Mode)
 
-<Preview>
+<Preview style={{ height: "250px" }}>
   <Story name="Multiple Dropdown Filter">
     <FilterMultipleDropdownStory />
   </Story>

--- a/modules/dropdown/Dropdown.story.tsx
+++ b/modules/dropdown/Dropdown.story.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import Dropdown, { IItem } from "./Dropdown";
-import MultipleDropdown from "./MultipleDropdown";
+import SimpleMultipleDropdown from "./SimpleMultipleDropdown";
+import FilterMultipleDropdown from "./FiltersMultipleDropdown";
 import { Text } from "@diana-ui/typography";
 import { useStyles } from "@diana-ui/base";
 import { ThemeStyleSheetFactory } from "@diana-ui/types";
@@ -27,7 +28,12 @@ const items = [
 ];
 
 const StyledDropdown = Dropdown.extendStyles(stylesheet);
-const StyledMultipleDropdown = MultipleDropdown.extendStyles(stylesheet);
+const StyledSimpleMultipleDropdown = SimpleMultipleDropdown.extendStyles(
+  stylesheet
+);
+const StyledFilterMultipleDropdown = FilterMultipleDropdown.extendStyles(
+  stylesheet
+);
 
 export const DropdownStory = () => {
   const [selectedItem, selectItem] = useState<IItem>();
@@ -41,11 +47,26 @@ export const DropdownStory = () => {
   );
 };
 
-export const MultipleDropdownStory = () => {
+export const SimpleMultipleDropdownStory = () => {
   const [selectedItems, selectItems] = useState<IItem[]>([]);
   const [styles, cx] = useStyles(stylesheet);
   return (
-    <StyledMultipleDropdown
+    <StyledSimpleMultipleDropdown
+      placeholder="Multiple Dropdown"
+      selectAllText="Select all"
+      selectedItems={selectedItems}
+      onItemsSelected={selectItems}
+      items={items}
+      renderItem={item => <Text className={cx(styles.hover)}>{item.text}</Text>}
+    />
+  );
+};
+
+export const FilterMultipleDropdownStory = () => {
+  const [selectedItems, selectItems] = useState<IItem[]>([]);
+  const [styles, cx] = useStyles(stylesheet);
+  return (
+    <StyledFilterMultipleDropdown
       placeholder="Multiple Dropdown"
       selectAllText="Select all"
       selectedItems={selectedItems}

--- a/modules/dropdown/Dropdown.tsx
+++ b/modules/dropdown/Dropdown.tsx
@@ -17,18 +17,18 @@ export interface IItem {
 export interface IProps<T extends IItem>
   extends PropsWithChildren<IPopoverProps> {
   items: T[];
-  renderItem?: (
-    item: T,
-    selected: boolean,
-    isAllSelected: boolean,
-    index?: number
-  ) => React.ReactNode;
   label?: string;
   text?: string;
   placeholder?: string;
 }
 
-export interface ISingleProps<T extends IItem> extends IProps<T> {
+export interface IRenderItem<T extends IItem> {
+  renderItem?: (item: T, selected: boolean, index?: number) => React.ReactNode;
+}
+
+export interface ISingleProps<T extends IItem>
+  extends IProps<T>,
+    IRenderItem<T> {
   onItemSelected: (item: T) => void;
   selectedItem?: T;
 }
@@ -166,7 +166,6 @@ const BaseDropdown: React.FC<PropsWithChildren<
               {renderItem?.(
                 item,
                 selectedItem !== undefined && selectedItem.id === item.id,
-                false,
                 index
               ) ?? <span className={cx(styles.itemText)}>{item.text}</span>}
             </li>

--- a/modules/dropdown/Dropdown.tsx
+++ b/modules/dropdown/Dropdown.tsx
@@ -17,7 +17,12 @@ export interface IItem {
 export interface IProps<T extends IItem>
   extends PropsWithChildren<IPopoverProps> {
   items: T[];
-  renderItem?: (item: T, selected: boolean, index?: number) => React.ReactNode;
+  renderItem?: (
+    item: T,
+    selected: boolean,
+    isAllSelected: boolean,
+    index?: number
+  ) => React.ReactNode;
   label?: string;
   text?: string;
   placeholder?: string;
@@ -161,6 +166,7 @@ const BaseDropdown: React.FC<PropsWithChildren<
               {renderItem?.(
                 item,
                 selectedItem !== undefined && selectedItem.id === item.id,
+                false,
                 index
               ) ?? <span className={cx(styles.itemText)}>{item.text}</span>}
             </li>

--- a/modules/dropdown/FiltersMultipleDropdown.tsx
+++ b/modules/dropdown/FiltersMultipleDropdown.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from "react";
+import { WithStylesProps } from "@diana-ui/types";
+import { withStyles } from "@diana-ui/base";
+import BaseMultipleDropdown, {
+  IMultipleProps,
+  multipleStylesheet
+} from "./BaseMultipleDropdown";
+import { IItem } from "./Dropdown";
+
+export interface IFilterMultipleDropDownProps<T extends IItem>
+  extends IMultipleProps<T> {}
+
+const StylesBaseMultipleDropdown = BaseMultipleDropdown.extendStyles(
+  multipleStylesheet
+);
+
+const FilterMultipleDropdown: React.FC<
+  IFilterMultipleDropDownProps<IItem> & WithStylesProps
+> = ({ onItemsSelected, items, ...props }) => {
+  const [isAllButtonChecked, setIsAllButtonChecked] = useState(false);
+
+  const onItemClicked = (item: IItem, selectedItems: IItem[]) => {
+    if (isAllButtonChecked) {
+      /**
+       * If isAllButtonChecked is true
+       * it means that when clicking on an element
+       * we want to select only that element
+       */
+      setIsAllButtonChecked(false);
+      onItemsSelected([item]);
+    } else {
+      let newItems = [...selectedItems];
+      const selected = newItems.find(i => i.id === item.id) !== undefined;
+      if (selected) {
+        /**
+         * In case this element is selected
+         * we want to check if it's the last one
+         * if so we reselect them all
+         * if not we just push it to the selectedItems
+         */
+        newItems = newItems.filter(i => i.id !== item.id);
+        if (newItems.length === 0) {
+          setIsAllButtonChecked(true);
+          newItems = [...items];
+        }
+      } else {
+        newItems.push(item);
+      }
+      onItemsSelected(newItems);
+    }
+  };
+  const onAllButtonClicked = () => {
+    setIsAllButtonChecked(!isAllButtonChecked);
+    onItemsSelected([...items]);
+  };
+
+  return (
+    <StylesBaseMultipleDropdown
+      items={items}
+      onItemsSelected={onItemsSelected}
+      isAllButtonChecked={isAllButtonChecked}
+      onItemClicked={onItemClicked}
+      onAllButtonClicked={onAllButtonClicked}
+      {...props}
+    />
+  );
+};
+
+export default withStyles(multipleStylesheet)(FilterMultipleDropdown);

--- a/modules/dropdown/SimpleMultipleDropdown.tsx
+++ b/modules/dropdown/SimpleMultipleDropdown.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { WithStylesProps } from "@diana-ui/types";
 import { withStyles } from "@diana-ui/base";
 import BaseMultipleDropdown, {
@@ -17,34 +17,58 @@ const StylesBaseMultipleDropdown = BaseMultipleDropdown.extendStyles(
 const SimpleMultipleDropdown: React.FC<
   ISimpleMultipleDropDownProps<IItem> & WithStylesProps
 > = ({ onItemsSelected, items, selectedItems, ...props }) => {
-  const isAllSelected = items.length === selectedItems.length;
+  const [draftItems, setDraftItems] = useState([...selectedItems]);
+  const isAllSelected = items.length === draftItems.length;
 
   const onItemClicked = (item: IItem) => {
-    let newItems = [...selectedItems];
+    let newItems = [...draftItems];
     const selected = newItems.find(i => i.id === item.id) !== undefined;
     if (selected) {
       newItems = newItems.filter(i => i.id !== item.id);
     } else {
       newItems.push(item);
     }
-    onItemsSelected(newItems);
+    setDraftItems(newItems);
   };
   const onAllButtonClicked = () => {
     if (isAllSelected) {
-      onItemsSelected([]);
+      setDraftItems([]);
     } else {
-      onItemsSelected([...items]);
+      setDraftItems([...items]);
     }
   };
 
+  const onClose = () => {
+    onItemsSelected([...draftItems]);
+  };
+
+  const { selected, rest } = React.useMemo(() => {
+    // eslint-disable-next-line consistent-return
+    return items.reduce(
+      (acc, item) => {
+        if (selectedItems.filter(elem => elem.id === item.id).length > 0) {
+          acc.selected.push(item);
+        } else {
+          acc.rest.push(item);
+        }
+        return acc;
+      },
+      {
+        selected: [] as IItem[],
+        rest: [] as IItem[]
+      }
+    );
+  }, [items, selectedItems]);
+
   return (
     <StylesBaseMultipleDropdown
-      items={items}
-      selectedItems={selectedItems}
+      items={[...selected, ...rest]}
+      selectedItems={draftItems}
       onItemsSelected={onItemsSelected}
       onItemClicked={onItemClicked}
       onAllButtonClicked={onAllButtonClicked}
       isAllButtonChecked={isAllSelected}
+      onClose={onClose}
       {...props}
     />
   );

--- a/modules/dropdown/SimpleMultipleDropdown.tsx
+++ b/modules/dropdown/SimpleMultipleDropdown.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { WithStylesProps } from "@diana-ui/types";
+import { withStyles } from "@diana-ui/base";
+import BaseMultipleDropdown, {
+  IMultipleProps,
+  multipleStylesheet
+} from "./BaseMultipleDropdown";
+import { IItem } from "./Dropdown";
+
+export interface ISimpleMultipleDropDownProps<T extends IItem>
+  extends IMultipleProps<T> {}
+
+const StylesBaseMultipleDropdown = BaseMultipleDropdown.extendStyles(
+  multipleStylesheet
+);
+
+const SimpleMultipleDropdown: React.FC<
+  ISimpleMultipleDropDownProps<IItem> & WithStylesProps
+> = ({ onItemsSelected, items, selectedItems, ...props }) => {
+  const isAllSelected = items.length === selectedItems.length;
+
+  const onItemClicked = (item: IItem) => {
+    let newItems = [...selectedItems];
+    const selected = newItems.find(i => i.id === item.id) !== undefined;
+    if (selected) {
+      newItems = newItems.filter(i => i.id !== item.id);
+    } else {
+      newItems.push(item);
+    }
+    onItemsSelected(newItems);
+  };
+  const onAllButtonClicked = () => {
+    if (isAllSelected) {
+      onItemsSelected([]);
+    } else {
+      onItemsSelected([...items]);
+    }
+  };
+
+  return (
+    <StylesBaseMultipleDropdown
+      items={items}
+      selectedItems={selectedItems}
+      onItemsSelected={onItemsSelected}
+      onItemClicked={onItemClicked}
+      onAllButtonClicked={onAllButtonClicked}
+      isAllButtonChecked={isAllSelected}
+      {...props}
+    />
+  );
+};
+
+export default withStyles(multipleStylesheet)(SimpleMultipleDropdown);

--- a/modules/dropdown/SimpleMultipleDropdown.tsx
+++ b/modules/dropdown/SimpleMultipleDropdown.tsx
@@ -7,7 +7,7 @@ import BaseMultipleDropdown, {
 } from "./BaseMultipleDropdown";
 import { IItem } from "./Dropdown";
 
-export interface ISimpleMultipleDropDownProps<T extends IItem>
+export interface ISimpleMultipleDropdownProps<T extends IItem>
   extends IMultipleProps<T> {}
 
 const StylesBaseMultipleDropdown = BaseMultipleDropdown.extendStyles(
@@ -15,7 +15,7 @@ const StylesBaseMultipleDropdown = BaseMultipleDropdown.extendStyles(
 );
 
 const SimpleMultipleDropdown: React.FC<
-  ISimpleMultipleDropDownProps<IItem> & WithStylesProps
+  ISimpleMultipleDropdownProps<IItem> & WithStylesProps
 > = ({ onItemsSelected, items, selectedItems, ...props }) => {
   const [draftItems, setDraftItems] = useState([...selectedItems]);
   const isAllSelected = items.length === draftItems.length;
@@ -39,11 +39,15 @@ const SimpleMultipleDropdown: React.FC<
   };
 
   const onClose = () => {
+    /**
+     * This dropdown has as feature be able to sort the selected items
+     * And since we don't want the ui to flick while selecting/desselecting elements
+     * Only on close we'll set the new `selectedItems`
+     */
     onItemsSelected([...draftItems]);
   };
 
   const { selected, rest } = React.useMemo(() => {
-    // eslint-disable-next-line consistent-return
     return items.reduce(
       (acc, item) => {
         if (selectedItems.filter(elem => elem.id === item.id).length > 0) {

--- a/modules/dropdown/index.ts
+++ b/modules/dropdown/index.ts
@@ -10,17 +10,5 @@ export {
 } from "./FiltersMultipleDropdown";
 export {
   default as MultipleDropdown,
-<<<<<<< HEAD
   ISimpleMultipleDropdownProps as IMultipleDropdownProps
-=======
-  IMultipleProps as IMultipleDropdownProps
-} from "./BaseMultipleDropdown";
-export {
-  default as FilterMultipleDropdown,
-  IFilterMultipleDropDownProps
-} from "./FiltersMultipleDropdown";
-export {
-  default as SimpleMultipleDropdown,
-  ISimpleMultipleDropDownProps
->>>>>>> feat(multidropdown.tsx): added some logical to select all button
 } from "./SimpleMultipleDropdown";

--- a/modules/dropdown/index.ts
+++ b/modules/dropdown/index.ts
@@ -10,5 +10,17 @@ export {
 } from "./FiltersMultipleDropdown";
 export {
   default as MultipleDropdown,
+<<<<<<< HEAD
   ISimpleMultipleDropdownProps as IMultipleDropdownProps
+=======
+  IMultipleProps as IMultipleDropdownProps
+} from "./BaseMultipleDropdown";
+export {
+  default as FilterMultipleDropdown,
+  IFilterMultipleDropDownProps
+} from "./FiltersMultipleDropdown";
+export {
+  default as SimpleMultipleDropdown,
+  ISimpleMultipleDropDownProps
+>>>>>>> feat(multidropdown.tsx): added some logical to select all button
 } from "./SimpleMultipleDropdown";

--- a/modules/dropdown/index.ts
+++ b/modules/dropdown/index.ts
@@ -7,4 +7,12 @@ export {
 export {
   default as MultipleDropdown,
   IMultipleProps as IMultipleDropdownProps
-} from "./MultipleDropdown";
+} from "./BaseMultipleDropdown";
+export {
+  default as FilterMultipleDropdown,
+  IFilterMultipleDropDownProps
+} from "./FiltersMultipleDropdown";
+export {
+  default as SimpleMultipleDropdown,
+  ISimpleMultipleDropDownProps
+} from "./SimpleMultipleDropdown";

--- a/modules/dropdown/index.ts
+++ b/modules/dropdown/index.ts
@@ -5,14 +5,10 @@ export {
   IItem as IDropdownItem
 } from "./Dropdown";
 export {
-  default as MultipleDropdown,
-  IMultipleProps as IMultipleDropdownProps
-} from "./BaseMultipleDropdown";
-export {
   default as FilterMultipleDropdown,
   IFilterMultipleDropDownProps
 } from "./FiltersMultipleDropdown";
 export {
-  default as SimpleMultipleDropdown,
-  ISimpleMultipleDropDownProps
+  default as MultipleDropdown,
+  ISimpleMultipleDropdownProps as IMultipleDropdownProps
 } from "./SimpleMultipleDropdown";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Normal dropdown behavior is now on (SimpleMultipleDropdown!

Added new logic to dropdown `all` selected (FiltersMultipleDropdown):
- When the user click on `All`, the items are able to have a different style.
- When `All` checked, and an item is clicked, only that one get's selected.
- When there's only one item selected, if the user tries to deselected it, it'll select all the items and the `All` 

## Motivation and Context
New feature on sales filter require this behavior, and as discussed with @nunoliveira12 we've agreed that we could have this logic be default.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
