### PR TITLE
feat(portal): add Portal module

### DIFF
--- a/modules/hooks/index.ts
+++ b/modules/hooks/index.ts
@@ -1,2 +1,3 @@
 export { default as useOnClickOutside } from "./useOnClickOutside";
 export { default as useRegistryWithStyles, useRegistry } from "./useRegistry";
+export { useWindowSize } from "./useWindowSize";

--- a/modules/hooks/useWindowSize.ts
+++ b/modules/hooks/useWindowSize.ts
@@ -1,0 +1,19 @@
+import { useLayoutEffect, useState } from "react";
+
+export const useWindowSize = () => {
+  const [size, setSize] = useState([0, 0]);
+
+  useLayoutEffect(() => {
+    const updateSize = () => {
+      setSize([window.innerWidth, window.innerHeight]);
+    };
+
+    window.addEventListener("resize", updateSize);
+
+    updateSize();
+
+    return () => window.removeEventListener("resize", updateSize);
+  }, []);
+
+  return size;
+};

--- a/modules/popover/Popover.tsx
+++ b/modules/popover/Popover.tsx
@@ -12,8 +12,7 @@ import {
 } from "@diana-ui/types";
 import { withStyles } from "@diana-ui/base";
 import { useOnClickOutside } from "@diana-ui/hooks";
-
-type Direction = "bottom" | "left" | "right" | "top";
+import { Portal, Direction } from "@diana-ui/portal";
 
 export interface IProps extends StandardProps<"div"> {
   renderHeader?: (visible: boolean) => React.ReactNode;
@@ -41,26 +40,12 @@ const styleSheet: ThemeStyleSheetFactory = () => ({
     cursor: "pointer"
   },
   popover: {
-    position: "absolute",
-    width: "100%",
     zIndex: 10
   },
-  bottom: {
-    top: "100%"
-  },
-  top: {
-    bottom: "100%"
-  },
-  left: {
-    top: 0,
-    bottom: 0,
-    right: "100%"
-  },
-  right: {
-    top: 0,
-    bottom: 0,
-    left: "100%"
-  }
+  bottom: {},
+  top: {},
+  left: {},
+  right: {}
 });
 
 const Popover: React.FC<PropsWithChildren<IProps & WithStylesProps>> = ({
@@ -115,7 +100,11 @@ const Popover: React.FC<PropsWithChildren<IProps & WithStylesProps>> = ({
         {renderHeader?.(visible)}
       </div>
       {visible && (
-        <div className={cx(styles.popover, styles[direction])}>{children}</div>
+        <Portal parentRef={divRef} direction={direction}>
+          <div className={cx(styles.popover, styles[direction])}>
+            {children}
+          </div>
+        </Portal>
       )}
     </div>
   );

--- a/modules/portal/Portal.story.mdx
+++ b/modules/portal/Portal.story.mdx
@@ -1,0 +1,68 @@
+import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import {
+  PortalStory,
+  TopPortalStory,
+  RightPortalStory,
+  LeftPortalStory
+} from "./Portal.story.tsx";
+
+<Meta title="Components | Portal" />
+
+# Portal
+
+The Portal component uses <a href="https://reactjs.org/docs/portals.html">React Portals</a> to render
+a DOM element outside the DOM hierarchy of the parent element, namely as a child of the `<body>`.
+
+This component was implemented for the `Popover` to be able to visibly overflow out of parents that have `overflow-hidden`.
+An example of this can be found when a `Dropdown` (that used the `Popover`) is rendered inside a `Modal`.
+
+<Preview>
+  <Story name="Portal">
+    <PortalStory />
+  </Story>
+</Preview>
+
+The `Portal` is absolutely positioned, and its position can be determined through the `direction` prop.
+To calculate that position, the parent element's position is used via the `parentRef` prop.
+
+<Preview>
+  <Story name="TopPortal">
+    <TopPortalStory />
+  </Story>
+</Preview>
+
+<Preview>
+  <Story name="RightPortal">
+    <RightPortalStory />
+  </Story>
+</Preview>
+
+<Preview>
+  <Story name="LeftPortal">
+    <LeftPortalStory />
+  </Story>
+</Preview>
+
+### Available props
+
+<table width="100%">
+  <thead>
+    <tr>
+      <th>Prop Name</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>direction (optional)</td>
+      <td>"bottom" (default) | "left" | "right" | "top"</td>
+      <td>Where to place the portal relative to the parent element</td>
+    </tr>
+    <tr>
+      <td>parentRef</td>
+      <td>{"React.RefObject<HTMLDivElement>"}</td>
+      <td>The parent element's ref</td>
+    </tr>
+  </tbody>
+</table>

--- a/modules/portal/Portal.story.tsx
+++ b/modules/portal/Portal.story.tsx
@@ -1,0 +1,77 @@
+import React, { useCallback, useRef, useState } from "react";
+import Portal from "./Portal";
+
+export const PortalStory = () => {
+  const [isPortalOpen, setPortalOpen] = useState(false);
+  const divRef = useRef<HTMLDivElement>(null);
+
+  const onClick = () => {
+    setPortalOpen(!isPortalOpen);
+  };
+
+  return (
+    <div ref={divRef}>
+      A Portal into a new dimension...
+      <button onClick={onClick}>Click to teleport</button>
+      {isPortalOpen && (
+        <Portal parentRef={divRef} direction="left">
+          This content is a hierarchical desdendant of {"<body>"}!
+        </Portal>
+      )}
+    </div>
+  );
+};
+
+export const TopPortalStory = () => {
+  const divRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <div style={{ display: "flex", justifyContent: "center" }}>
+      <div
+        style={{ display: "inline-block", backgroundColor: "burlywood" }}
+        ref={divRef}
+      >
+        Parent component
+        <Portal parentRef={divRef} direction="top">
+          Top aligned
+        </Portal>
+      </div>
+    </div>
+  );
+};
+
+export const RightPortalStory = () => {
+  const divRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <div style={{ display: "flex", justifyContent: "center" }}>
+      <div
+        style={{ display: "inline-block", backgroundColor: "burlywood" }}
+        ref={divRef}
+      >
+        Parent component
+        <Portal parentRef={divRef} direction="right">
+          Right aligned
+        </Portal>
+      </div>
+    </div>
+  );
+};
+
+export const LeftPortalStory = () => {
+  const divRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <div style={{ display: "flex", justifyContent: "center" }}>
+      <div
+        style={{ display: "inline-block", backgroundColor: "burlywood" }}
+        ref={divRef}
+      >
+        Parent component
+        <Portal parentRef={divRef} direction="left">
+          Left aligned
+        </Portal>
+      </div>
+    </div>
+  );
+};

--- a/modules/portal/Portal.story.tsx
+++ b/modules/portal/Portal.story.tsx
@@ -14,7 +14,7 @@ export const PortalStory = () => {
       A Portal into a new dimension...
       <button onClick={onClick}>Click to teleport</button>
       {isPortalOpen && (
-        <Portal parentRef={divRef} direction="left">
+        <Portal parentRef={divRef}>
           This content is a hierarchical desdendant of {"<body>"}!
         </Portal>
       )}

--- a/modules/portal/Portal.tsx
+++ b/modules/portal/Portal.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useMemo } from "react";
+import { createPortal } from "react-dom";
+import { useWindowSize } from "@diana-ui/hooks";
+
+export type Direction = "bottom" | "left" | "right" | "top";
+
+export interface IProps {
+  direction?: Direction;
+  parentRef: React.RefObject<HTMLDivElement>;
+}
+
+const getScrollTop = () => document.documentElement.scrollTop;
+
+const getPortalStyles = (
+  ref: React.RefObject<HTMLDivElement>,
+  direction: Direction
+) => {
+  const dimensions = ref.current?.getBoundingClientRect();
+
+  let styles = "position: absolute; ";
+
+  switch (direction) {
+    case "top": {
+      styles += `left: ${dimensions?.left}px; top: ${
+        dimensions && dimensions?.top - dimensions?.height + getScrollTop()
+      }px;`;
+      break;
+    }
+    case "right": {
+      styles += `left: ${dimensions?.right}px; top: ${
+        dimensions && dimensions?.top + getScrollTop()
+      }px;`;
+      break;
+    }
+    case "bottom": {
+      styles += `left: ${dimensions?.left}px; top: ${
+        dimensions && dimensions?.top + dimensions?.height + getScrollTop()
+      }px;`;
+      break;
+    }
+    case "left": {
+      styles += `right: ${dimensions?.right}px; top: ${
+        dimensions && dimensions?.top + getScrollTop()
+      }px;`;
+      break;
+    }
+    default:
+      break;
+  }
+
+  return styles;
+};
+
+const Portal: React.FC<IProps> = ({
+  direction = "bottom",
+  parentRef,
+  children
+}) => {
+  const windowSize = useWindowSize();
+
+  const target = useMemo(() => document.createElement("div"), []);
+
+  // If window size changes, recalculate position based on new parentRef position
+  // This effect also sets the initial position
+  useEffect(() => {
+    target.setAttribute("style", getPortalStyles(parentRef, direction));
+  }, [direction, parentRef, target, windowSize]);
+
+  useEffect(() => {
+    document.body.appendChild(target);
+
+    return () => {
+      target.remove();
+    };
+  }, [target]);
+
+  return createPortal(children, target);
+};
+
+export default Portal;

--- a/modules/portal/README.md
+++ b/modules/portal/README.md
@@ -1,0 +1,10 @@
+## @diana-ui/portal
+
+The Portal component uses <a href="https://reactjs.org/docs/portals.html">React Portals</a> to render
+a DOM element outside the DOM hierarchy of the parent element, namely as a child of the `<body>`.
+
+This component was implemented for the `Popover` to be able to visibly overflow out of parents that have `overflow-hidden`.
+An example of this can be found when a `Dropdown` (that used the `Popover`) is rendered inside a `Modal`.
+
+The `Portal` is absolutely positioned, just below its parent element and aligned on the left side. To calculate this position,
+the parent element's position is used via the `parentRef` prop.

--- a/modules/portal/index.ts
+++ b/modules/portal/index.ts
@@ -1,0 +1,1 @@
+export { default as Portal, IProps as IPortalProps, Direction } from "./Portal";

--- a/modules/portal/package.json
+++ b/modules/portal/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@diana-ui/popover",
-  "version": "0.1.3",
+  "name": "@diana-ui/portal",
+  "version": "0.0.1",
   "main": "lib/index.js",
   "module": "module/index.js",
   "files": [
@@ -16,13 +16,12 @@
     "prepare": "yarn clean:files && yarn build"
   },
   "peerDependencies": {
-    "react": "^16.12.0"
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0"
   },
   "dependencies": {
-    "@diana-ui/base": "^0.1.1",
-    "@diana-ui/hooks": "^0.1.1",
-    "@diana-ui/portal": "^0.0.1",
-    "@diana-ui/types": "^0.1.1"
+    "@diana-ui/hooks": "0.1.0",
+    "@diana-ui/types": "0.1.0"
   },
   "publishConfig": {
     "access": "public"

--- a/modules/portal/tsconfig.json
+++ b/modules/portal/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}


### PR DESCRIPTION
Add Portal module, which allows a DOM node to be rendered outside the DOM hierarchy of the parent
element. This is used for the Dropdown to visibly overflow out of Modals.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
