### PR TITLE
fix(portal.tsx): fix problem on dropdown

### DIFF
--- a/modules/portal/Portal.tsx
+++ b/modules/portal/Portal.tsx
@@ -9,6 +9,7 @@ export interface IProps extends StandardProps<"div"> {
   direction?: Direction;
   parentRef: React.RefObject<HTMLDivElement>;
   useParentWidth?: boolean;
+  scrollableRootElement?: string | HTMLElement;
 }
 
 const getScrollTop = () => document.documentElement.scrollTop;
@@ -62,6 +63,7 @@ const Portal: React.FC<IProps> = ({
   direction = "bottom",
   parentRef,
   useParentWidth = false,
+  scrollableRootElement = "root",
   children
 }) => {
   const windowSize = useWindowSize();
@@ -71,11 +73,34 @@ const Portal: React.FC<IProps> = ({
   // If window size changes, recalculate position based on new parentRef position
   // This effect also sets the initial position
   useEffect(() => {
-    target.setAttribute(
-      "style",
-      getPortalStyles(parentRef, direction, useParentWidth)
-    );
-  }, [direction, parentRef, target, useParentWidth, windowSize]);
+    const updateTargetStyle = () => {
+      target.setAttribute(
+        "style",
+        getPortalStyles(parentRef, direction, useParentWidth)
+      );
+    };
+    updateTargetStyle();
+    if (scrollableRootElement) {
+      const rootElement =
+        typeof scrollableRootElement === "string"
+          ? document.getElementById(scrollableRootElement)
+          : scrollableRootElement;
+
+      if (rootElement) {
+        rootElement.addEventListener("scroll", updateTargetStyle);
+      }
+
+      return () =>
+        rootElement?.removeEventListener("scroll", updateTargetStyle);
+    }
+  }, [
+    direction,
+    parentRef,
+    scrollableRootElement,
+    target,
+    useParentWidth,
+    windowSize
+  ]);
 
   useEffect(() => {
     document.body.appendChild(target);


### PR DESCRIPTION

## Description
This problem was caused because when user scrolls the page, the portal component wasn't updating the
position. Therefore, now there's a listener that'll update this positions keeping the component in
his place.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
