### PR TITLE
improvement(expandable-panel): add ResizeObserver to expandable panel to properly adjust body height

### DIFF
--- a/modules/expandable-panel/ExpandablePanel.story.mdx
+++ b/modules/expandable-panel/ExpandablePanel.story.mdx
@@ -4,6 +4,7 @@ import {
   ExpandablePanelStory,
   DisabledExpandablePanelStory,
   ExpandedPanelStory,
+  DynamicExpandedPanelStory,
   ExpandablePanelsStory,
   DisabledExpandablePanelsStory,
   ExpandedPanelsStory,
@@ -36,6 +37,14 @@ Its expanded/collapsed state can either be controlled by the component internall
 <Preview>
   <Story name="expanded ExpandablePanel">
     <ExpandedPanelStory />
+  </Story>
+</Preview>
+
+### Dynamic content
+
+<Preview>
+  <Story name="ExpandablePanel with dynamic content">
+    <DynamicExpandedPanelStory />
   </Story>
 </Preview>
 

--- a/modules/expandable-panel/ExpandablePanel.story.tsx
+++ b/modules/expandable-panel/ExpandablePanel.story.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import ExpandablePanels from "./ExpandablePanels";
 import ExpandablePanel from "./ExpandablePanel";
 
@@ -28,6 +28,38 @@ export const ExpandedPanelStory = () => {
       <span style={{ padding: "32px", border: "1px solid black" }}>
         I have been expanded!
       </span>
+    </ExpandablePanel>
+  );
+};
+
+export const DynamicExpandedPanelStory = () => {
+  const [numElements, setNumElements] = useState(1);
+
+  const handleContentAdd = () => {
+    setNumElements(numElements + 1);
+  };
+
+  const handleContentRemove = () => {
+    if (numElements > 0) {
+      setNumElements(numElements - 1);
+    }
+  };
+
+  return (
+    <ExpandablePanel header="Expand me!" initialExpanded>
+      <div style={{ display: "flex", flexDirection: "column" }}>
+        <div style={{ display: "flex" }}>
+          <button onClick={handleContentAdd} style={{ marginRight: "32px" }}>
+            Add content
+          </button>
+          <button onClick={handleContentRemove}>Remove content</button>
+        </div>
+        {[...Array(numElements)].map((_, i) => (
+          <span key={i} style={{ padding: "32px", border: "1px solid black" }}>
+            This is a dom element
+          </span>
+        ))}
+      </div>
     </ExpandablePanel>
   );
 };

--- a/modules/expandable-panel/ExpandablePanel.tsx
+++ b/modules/expandable-panel/ExpandablePanel.tsx
@@ -12,10 +12,9 @@ import {
   ThemeStyleSheetFactory,
   Theme
 } from "@diana-ui/types";
-import { useWindowSize } from "@diana-ui/hooks";
+import { useResizeObserver, useWindowSize } from "@diana-ui/hooks";
 import { Icon } from "@diana-ui/icon";
 import { BodyHighlight } from "@diana-ui/typography";
-import { ResizeObserver } from "@juggle/resize-observer";
 
 const SLIDE_ANIMATION_DURATION_MS = 200;
 
@@ -109,17 +108,16 @@ const ExpandablePanel: React.FC<IProps & WithStylesProps> = ({
   }, [headerRef, windowSize]);
 
   // observer that keeps track of body height and sets bodyHeight accordingly
-  const bodyResizeObserver = useMemo(
-    () =>
-      new ResizeObserver(entries => {
-        entries.forEach(entry => {
-          const { blockSize: height } = entry.contentBoxSize[0];
+  const bodyResizeObserver = useResizeObserver(
+    entries => {
+      entries.forEach(entry => {
+        const { height } = entry.contentRect;
 
-          if (height !== bodyHeight) {
-            setBodyHeight(height);
-          }
-        });
-      }),
+        if (height !== bodyHeight) {
+          setBodyHeight(height);
+        }
+      });
+    },
     [bodyHeight]
   );
 

--- a/modules/expandable-panel/ExpandablePanel.tsx
+++ b/modules/expandable-panel/ExpandablePanel.tsx
@@ -15,6 +15,7 @@ import {
 import { useWindowSize } from "@diana-ui/hooks";
 import { Icon } from "@diana-ui/icon";
 import { BodyHighlight } from "@diana-ui/typography";
+import { ResizeObserver } from "@juggle/resize-observer";
 
 const SLIDE_ANIMATION_DURATION_MS = 200;
 
@@ -29,10 +30,10 @@ export interface IProps extends StandardProps<"div"> {
 
 const stylesheet: ThemeStyleSheetFactory = (theme: Theme) => ({
   body: {
-    display: "flex",
-    overflow: "hidden"
+    display: "flex"
   },
   bodyWrapper: {
+    overflow: "auto",
     transition: `height ${SLIDE_ANIMATION_DURATION_MS}ms ease-out`
   },
   header: {
@@ -107,12 +108,35 @@ const ExpandablePanel: React.FC<IProps & WithStylesProps> = ({
     setHeaderHeight(headerRef.current?.offsetHeight);
   }, [headerRef, windowSize]);
 
-  // calculate body height (once or every time window size changes)
+  // observer that keeps track of body height and sets bodyHeight accordingly
+  const bodyResizeObserver = useMemo(
+    () =>
+      new ResizeObserver(entries => {
+        entries.forEach(entry => {
+          const { blockSize: height } = entry.contentBoxSize[0];
+
+          if (height !== bodyHeight) {
+            setBodyHeight(height);
+          }
+        });
+      }),
+    [bodyHeight]
+  );
+
+  // observe body element resizing if panel is expanded
   useEffect(() => {
-    if (bodyHeight === 0 || bodyHeight === undefined) {
-      setBodyHeight(bodyRef.current?.offsetHeight);
+    const bodyEl = bodyRef.current;
+
+    if (bodyEl) {
+      bodyResizeObserver.observe(bodyEl);
     }
-  }, [bodyHeight, bodyRef, isExpanded, windowSize]);
+
+    return () => {
+      if (bodyEl) {
+        bodyResizeObserver.unobserve(bodyEl);
+      }
+    };
+  }, [isExpanded, bodyResizeObserver]);
 
   const handleCollapse = useCallback(() => {
     setCurrentBodyHeight(0);
@@ -126,7 +150,7 @@ const ExpandablePanel: React.FC<IProps & WithStylesProps> = ({
 
   // set body height manually to be able to have the sliding animation
   useEffect(() => {
-    if (isExpanded && bodyHeight && bodyHeight > 0 && currentBodyHeight === 0) {
+    if (isExpanded && bodyHeight && bodyHeight > 0) {
       const timeout = setTimeout(() => {
         setCurrentBodyHeight(bodyHeight);
       }, 250);

--- a/modules/expandable-panel/package.json
+++ b/modules/expandable-panel/package.json
@@ -20,7 +20,8 @@
     "@diana-ui/hooks": "^0.1.14",
     "@diana-ui/icon": "^0.2.2",
     "@diana-ui/types": "^0.1.8",
-    "@diana-ui/typography": "^0.1.11"
+    "@diana-ui/typography": "^0.1.11",
+    "@juggle/resize-observer": "3.1.3"
   },
   "peerDependencies": {
     "react": "^16.12.0"

--- a/modules/expandable-panel/package.json
+++ b/modules/expandable-panel/package.json
@@ -20,8 +20,7 @@
     "@diana-ui/hooks": "^0.1.14",
     "@diana-ui/icon": "^0.2.2",
     "@diana-ui/types": "^0.1.8",
-    "@diana-ui/typography": "^0.1.11",
-    "@juggle/resize-observer": "3.1.3"
+    "@diana-ui/typography": "^0.1.11"
   },
   "peerDependencies": {
     "react": "^16.12.0"

--- a/modules/hooks/index.ts
+++ b/modules/hooks/index.ts
@@ -1,3 +1,4 @@
 export { default as useOnClickOutside } from "./useOnClickOutside";
 export { default as useRegistryWithStyles, useRegistry } from "./useRegistry";
+export { useResizeObserver } from "./useResizeObserver";
 export { useWindowSize } from "./useWindowSize";

--- a/modules/hooks/package.json
+++ b/modules/hooks/package.json
@@ -21,7 +21,8 @@
   },
   "dependencies": {
     "@diana-ui/base": "^0.1.11",
-    "@diana-ui/types": "^0.1.8"
+    "@diana-ui/types": "^0.1.8",
+    "@juggle/resize-observer": "3.1.3"
   },
   "publishConfig": {
     "access": "public"

--- a/modules/hooks/useResizeObserver.ts
+++ b/modules/hooks/useResizeObserver.ts
@@ -1,0 +1,18 @@
+import { useMemo } from "react";
+import {
+  ResizeObserver as Polyfill,
+  ResizeObserverEntry
+} from "@juggle/resize-observer";
+
+const ResizeObserver = (window as any).ResizeObserver || Polyfill;
+
+export function useResizeObserver(
+  callback: (entries: ResizeObserverEntry[]) => void,
+  dependencies: any[]
+) {
+  return useMemo(() => new ResizeObserver(callback), [
+    callback,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    ...dependencies
+  ]);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1479,6 +1479,11 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
+"@juggle/resize-observer@3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.1.3.tgz#d7373eb9a1afc371342b8cf1a07e34368f3d65d7"
+  integrity sha512-y7qc6SzZBlSpx8hEDfV0S9Cx6goROX/vBhS2Ru1Q78Jp1FlCMbxp7UcAN90rLgB3X8DSMBgDFxcmoG/VfdAhFA==
+
 "@lerna/add@3.20.0":
   version "3.20.0"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.20.0.tgz#bea7edf36fc93fb72ec34cb9ba854c48d4abf309"


### PR DESCRIPTION
## Description
The panel body height was being calculated only once and wasn't taking resizings into account.
In this PR we add a [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) to monitor changes to that height and adjust the expandable panel height accordingly.

A [new dependency](https://github.com/juggle/resize-observer) has been added, which is a polyfill to the mentioned ResizeObserver.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
