### PR TITLE
feature(portal): reposition portal if it is (partially) outside viewport

### DIFF
--- a/modules/portal/Portal.story.mdx
+++ b/modules/portal/Portal.story.mdx
@@ -7,7 +7,8 @@ import {
   CenteredPortalStory,
   BottomRightPortalStory,
   TopRightPortalStory,
-  CenterTopPortalStory
+  CenterTopPortalStory,
+  OverflowPortalStory
 } from "./Portal.story.tsx";
 
 <Meta title="Components | Portal" />
@@ -71,6 +72,21 @@ To calculate that position, the parent element's position is used via the `paren
   </Story>
 </Preview>
 
+### Repositioning partially hidden Portals
+
+If the element were to be rendered (partially) outside the viewport, a new direction will be chosen and the Portal's position will be recalculated until either
+the element is not outside the viewport or the element is outside the viewport no matter the direction.
+In the latter case, the original direction is used.
+
+Vertical clipping of the Portal is not taken into account for repositioning purposes, as it represents a more complex problem due to how common vertical scrolling
+is. This can be revisited in the future.
+
+<Preview>
+  <Story name="Partially hidden">
+    <OverflowPortalStory />
+  </Story>
+</Preview>
+
 ### Available props
 
 <table width="100%">
@@ -89,7 +105,7 @@ To calculate that position, the parent element's position is used via the `paren
     </tr>
     <tr>
       <td>direction (optional)</td>
-      <td>"bottom" (default) | "left" | "right" | "top"</td>
+      <td>"bottom" (default) | "left" | "right" | "top" | "bottom-right" | "top-right"</td>
       <td>Where to place the portal relative to the parent element</td>
     </tr>
     <tr>

--- a/modules/portal/Portal.story.tsx
+++ b/modules/portal/Portal.story.tsx
@@ -1,5 +1,7 @@
 import React, { useRef, useState } from "react";
-import Portal from "./Portal";
+import { Dropdown, IDropdownItem } from "@diana-ui/dropdown";
+import { Toggle } from "@diana-ui/toggle";
+import Portal, { Direction } from "./Portal";
 
 export const PortalStory = () => {
   const [isPortalOpen, setPortalOpen] = useState(false);
@@ -127,9 +129,60 @@ export const CenterTopPortalStory = () => {
     <div style={{ display: "flex", justifyContent: "center" }}>
       <div style={{ display: "inline-block", backgroundColor: "burlywood" }} ref={divRef}>
         Parent component
-        <Portal parentRef={divRef} direction="center-top">
-          <div>center top text aligned</div>
+        <Portal parentRef={divRef} direction="top" centered>
+          center top text aligned
         </Portal>
+      </div>
+    </div>
+  );
+};
+
+export const OverflowPortalStory = () => {
+  const divRef = useRef<HTMLDivElement>(null);
+  const [direction, setDirection] = useState<IDropdownItem>({ id: "top", text: "top" });
+  const [isCentered, setIsCentered] = useState<boolean>(true);
+  const directions = [
+    { id: "top", text: "top" },
+    { id: "top-right", text: "top-right" },
+    { id: "left", text: "left" },
+    { id: "bottom", text: "bottom" },
+    { id: "bottom-right", text: "bottom-right" },
+    { id: "right", text: "right" }
+  ];
+
+  console.log("isCentered", isCentered);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column" }}>
+      <div
+        style={{
+          display: "inline-block",
+          backgroundColor: "burlywood",
+          width: "fit-content",
+          alignSelf: "flex-start"
+        }}
+        ref={divRef}
+      >
+        Parent component
+        <Portal parentRef={divRef} direction={direction?.id as Direction} centered={isCentered}>
+          <div style={{ width: "300px" }}>
+            I will always be partially hidden if placed on the left!
+          </div>
+        </Portal>
+      </div>
+      <div style={{ display: "flex", alignSelf: "center", marginTop: "48px" }}>
+        <Dropdown
+          label="choose direction: "
+          items={directions}
+          selectedItem={direction}
+          onItemSelected={setDirection}
+        />
+        <Toggle
+          checked={isCentered}
+          onChange={() => setIsCentered(currentIsCentered => !currentIsCentered)}
+        >
+          isCentered
+        </Toggle>
       </div>
     </div>
   );

--- a/modules/portal/Portal.story.tsx
+++ b/modules/portal/Portal.story.tsx
@@ -140,6 +140,7 @@ export const CenterTopPortalStory = () => {
 export const OverflowPortalStory = () => {
   const divRef = useRef<HTMLDivElement>(null);
   const [direction, setDirection] = useState<IDropdownItem>({ id: "top", text: "top" });
+  const [align, setAlign] = useState<IDropdownItem>({ id: "flex-start", text: "flex-start" });
   const [isCentered, setIsCentered] = useState<boolean>(true);
   const directions = [
     { id: "top", text: "top" },
@@ -148,6 +149,10 @@ export const OverflowPortalStory = () => {
     { id: "bottom", text: "bottom" },
     { id: "bottom-right", text: "bottom-right" },
     { id: "right", text: "right" }
+  ];
+  const aligns = [
+    { id: "flex-start", text: "flex-start" },
+    { id: "flex-end", text: "flex-end" }
   ];
 
   console.log("isCentered", isCentered);
@@ -159,14 +164,20 @@ export const OverflowPortalStory = () => {
           display: "inline-block",
           backgroundColor: "burlywood",
           width: "fit-content",
-          alignSelf: "flex-start"
+          alignSelf: align?.id
         }}
         ref={divRef}
       >
         Parent component
-        <Portal parentRef={divRef} direction={direction?.id as Direction} centered={isCentered}>
+        <Portal
+          zIndex={align?.id == "flex-start" ? 100 : 99}
+          parentRef={divRef}
+          direction={direction?.id as Direction}
+          centered={isCentered}
+        >
           <div style={{ width: "300px" }}>
-            I will always be partially hidden if placed on the left!
+            I will always be partially hidden if placed on the{" "}
+            {align?.id == "flex-start" ? "left" : "right"}!
           </div>
         </Portal>
       </div>
@@ -176,6 +187,12 @@ export const OverflowPortalStory = () => {
           items={directions}
           selectedItem={direction}
           onItemSelected={setDirection}
+        />
+        <Dropdown
+          label="choose align: "
+          items={aligns}
+          selectedItem={align}
+          onItemSelected={setAlign}
         />
         <Toggle
           checked={isCentered}

--- a/modules/portal/Portal.story.tsx
+++ b/modules/portal/Portal.story.tsx
@@ -155,8 +155,6 @@ export const OverflowPortalStory = () => {
     { id: "flex-end", text: "flex-end" }
   ];
 
-  console.log("isCentered", isCentered);
-
   return (
     <div style={{ display: "flex", flexDirection: "column" }}>
       <div

--- a/modules/portal/package.json
+++ b/modules/portal/package.json
@@ -24,6 +24,10 @@
     "@diana-ui/hooks": "^1.0.3",
     "@diana-ui/types": "^1.0.2"
   },
+  "devDependencies": {
+    "@diana-ui/dropdown": "^1.0.6",
+    "@diana-ui/toggle": "^1.0.1"
+  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
You can test this out by running the storybook and playing around with the last story. 
If you manually set `align-self: "flex-end"` to the parent component, you can check out the rest of the repositioning behaviour.

This should fix problems like these:
![image](https://user-images.githubusercontent.com/46319073/90789961-6bb84e00-e2ff-11ea-9e72-4ebc2659fee0.png)
